### PR TITLE
✨Feat: 경기 데이터 동기화

### DIFF
--- a/src/main/java/com/scorenow/scorenow_api/domain/league/entity/League.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/entity/League.java
@@ -1,20 +1,36 @@
 package com.scorenow.scorenow_api.domain.league.entity;
 
 import com.scorenow.scorenow_api.global.entity.BaseEntity;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Table(name = "leagues")
-@Getter @Setter
+@Getter
+@Setter
 @NoArgsConstructor
-public class League extends BaseEntity{
-    @Id
-    private String id; // BETS + sportId + leagueId
-    private String sportId;
-    private String kName;
-    private String eName;
-    private String sName; // 숏네임
+@AllArgsConstructor
+@Builder
+public class League extends BaseEntity {
+	@Id
+	private String id; // BETS + sportId + leagueId
+	private String sportId;
+	private String kName;
+	private String eName;
+	private String sName; // 숏네임
+	private String cc;
+
+	@Builder.Default
+	private boolean isActive = true;
+
+	public static String generateLeagueId(String sportId, String leagueId) {
+		return "BETS" + sportId + leagueId;
+	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/repository/LeagueRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/repository/LeagueRepository.java
@@ -1,0 +1,8 @@
+package com.scorenow.scorenow_api.domain.league.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.scorenow.scorenow_api.domain.league.entity.League;
+
+public interface LeagueRepository extends JpaRepository<League, String> {
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
@@ -8,8 +8,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -52,22 +50,8 @@ public class Match extends BaseEntity {
 	private String betsApiEventId;
 	private String bet365Id;
 
-	private LocalDateTime createdAt;
-	private LocalDateTime updatedAt;
-
 	public static String generateMatchId(String sportId, String eventId) {
 		return "BETS" + sportId + eventId;
-	}
-
-	@PrePersist
-	public void prePersist() {
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = LocalDateTime.now();
-	}
-
-	@PreUpdate
-	public void preUpdate() {
-		this.updatedAt = LocalDateTime.now();
 	}
 }
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
@@ -1,43 +1,73 @@
 package com.scorenow.scorenow_api.domain.match.entity;
 
+import java.time.LocalDateTime;
+
 import com.scorenow.scorenow_api.global.entity.BaseEntity;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "matches")
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Match extends BaseEntity {
-    @Id
-    private String id; // BETS + sportId + eventId (예: BETS111275660)
+	@Id
+	private String id; // BETS + sportId + eventId (예: BETS111275660)
 
-    private String leagueId; // BETS + sportId + leagueId
-    private String sportId;
-    private String homeId;   // BETS + sportId + teamId
-    private String awayId;   // BETS + sportId + teamId
+	private String leagueId; // BETS + sportId + leagueId
+	private String sportId;
+	private String homeId;   // BETS + sportId + teamId
+	private String awayId;   // BETS + sportId + teamId
 
-    @Enumerated(EnumType.STRING)
-    private MatchStatus statusCode;
+	@Enumerated(EnumType.STRING)
+	private MatchStatus statusCode;
 
+	private Integer homeScore;
+	private Integer awayScore;
+	private LocalDateTime startAt;
 
-    private Integer homeScore;
-    private Integer awayScore;
-    private LocalDateTime startAt;
+	@Builder.Default
+	private String matchType = "A"; // 기본 A로 세팅
 
-    @Column(length = 10, columnDefinition = "VARCHAR(10) DEFAULT 'A'")
-    private String matchType = "A"; // 기본 A로 세팅
+	@Builder.Default
+	private boolean isManual = false;
 
-    @Column(columnDefinition = "TINYINT(1) DEFAULT 0")
-    private boolean isManual;
+	@Builder.Default
+	private boolean isActive = true;
 
-    @Column(columnDefinition = "TINYINT(1) DEFAULT 0")
-    private boolean isActive;
+	private String betsApiEventId;
+	private String bet365Id;
 
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+
+	public static String generateMatchId(String sportId, String eventId) {
+		return "BETS" + sportId + eventId;
+	}
+
+	@PrePersist
+	public void prePersist() {
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	@PreUpdate
+	public void preUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
 }
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchStatus.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchStatus.java
@@ -6,18 +6,29 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MatchStatus {
-    NOT_STARTED("0", "경기전"),
-    IN_PLAY("1", "진행중"),
-    TO_BE_FIXED("2", "수정예정"),
-    ENDED("3", "종료"),
-    POSTPONED("4", "연기"),
-    CANCELLED("5", "취소"),
-    WALKOVER("6", "부전승"),
-    INTERRUPTED("7", "중지"),
-    ABANDONED("8", "취소"),
-    RETIRED("9", "기권"),
-    REMOVED("99", "삭제");
+	NOT_STARTED("0", "경기전"),
+	IN_PLAY("1", "진행중"),
+	TO_BE_FIXED("2", "수정예정"),
+	ENDED("3", "종료"),
+	POSTPONED("4", "연기"),
+	CANCELLED("5", "취소"),
+	WALKOVER("6", "부전승"),
+	INTERRUPTED("7", "중지"),
+	ABANDONED("8", "취소"),
+	RETIRED("9", "기권"),
+	REMOVED("99", "삭제");
 
-    private final String code;
-    private final String description;
+	private final String code;
+	private final String description;
+
+	public static MatchStatus fromCode(String code) {
+		if (code == null)
+			return NOT_STARTED;
+		for (MatchStatus status : values()) {
+			if (status.code.equals(code)) {
+				return status;
+			}
+		}
+		return NOT_STARTED;
+	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/MatchRepository.java
@@ -1,0 +1,8 @@
+package com.scorenow.scorenow_api.domain.match.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+
+public interface MatchRepository extends JpaRepository<Match, String> {
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchSyncService.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.function.BiFunction;
 
 import org.springframework.stereotype.Service;
 
@@ -26,6 +27,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MatchSyncService {
 
+	private static final int MAX_SYNC_PAGES = 10;
+	private static final int PER_PAGE_SIZE = 50;
+	private static final String TEAM_IMAGE_BASE_URL = "https://assets.b365api.com/images/team/m/";
+	private static final ZoneId DEFAULT_ZONE_ID = ZoneId.of("Asia/Seoul");
+
 	private final BetsApiClient betsApiClient;
 	private final MatchRepository matchRepository;
 	private final LeagueRepository leagueRepository;
@@ -36,40 +42,8 @@ public class MatchSyncService {
 	 */
 	@Transactional
 	public int syncUpcomingMatches(String sportId, String day) {
-		if (day == null) {
-			day = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-		}
-
-		log.info("예정 경기 동기화 시작 - sportsId: {}, day: {}", sportId, day);
-
-		int totalSynced = 0;
-		int page = 1;
-
-		while (page <= 10) {
-			BetsEventResponse response = betsApiClient.getUpcomingEvents(sportId, day, page);
-
-			if (response == null || response.getResults() == null || response.getResults().isEmpty()) {
-				break;
-			}
-
-			for (BetsEventResponse.Event event : response.getResults()) {
-				try {
-					syncEvent(event, sportId);
-					totalSynced++;
-				} catch (Exception e) {
-					log.error("경기 동기화 실패 - eventId: {}, error: {}", event.getId(), e.getMessage());
-				}
-			}
-
-			// 다음 페이지 있는지 확인
-			if (response.getResults().size() < response.getPager().getPerPage()) {
-				break;
-			}
-			page++;
-		}
-
-		log.info("예정 경기 동기화 완료 - 총 {}건", totalSynced);
-		return totalSynced;
+		return syncMatchesWithPagination(sportId, day, "예정",
+			(normalizedDay, page) -> betsApiClient.getUpcomingEvents(sportId, normalizedDay, page));
 	}
 
 	/**
@@ -104,17 +78,27 @@ public class MatchSyncService {
 	 */
 	@Transactional
 	public int syncEndedMatches(String sportId, String day) {
+		return syncMatchesWithPagination(sportId, day, "종료",
+			(normalizedDay, page) -> betsApiClient.getEndedEvents(sportId, normalizedDay, page));
+	}
+
+	/**
+	 * 페이지네이션 기반 경기 동기화 공통 로직.
+	 * fetchPage: (sportId, day, page) -> BetsEventResponse 형태로 API를 호출하는 함수.
+	 */
+	private int syncMatchesWithPagination(String sportId, String day, String logLabel,
+		BiFunction<String, Integer, BetsEventResponse> fetchPage) {
 		if (day == null) {
 			day = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 		}
 
-		log.info("종료 경기 동기화 시작 - sportId: {}, day: {}", sportId, day);
+		log.info("{} 경기 동기화 시작 - sportId: {}, day: {}", logLabel, sportId, day);
 
 		int totalSynced = 0;
 		int page = 1;
 
-		while (page <= 10) {
-			BetsEventResponse response = betsApiClient.getEndedEvents(sportId, day, page);
+		while (page <= MAX_SYNC_PAGES) {
+			BetsEventResponse response = fetchPage.apply(day, page);
 
 			if (response == null || response.getResults() == null || response.getResults().isEmpty()) {
 				break;
@@ -129,13 +113,13 @@ public class MatchSyncService {
 				}
 			}
 
-			if (response.getResults().size() < response.getPager().getPerPage()) {
+			if (response.getResults().size() < PER_PAGE_SIZE) {
 				break;
 			}
 			page++;
 		}
 
-		log.info("종료 경기 동기화 완료 - 총 {}건", totalSynced);
+		log.info("{} 경기 동기화 완료 - 총 {}건", logLabel, totalSynced);
 		return totalSynced;
 	}
 
@@ -183,7 +167,7 @@ public class MatchSyncService {
 		if (!teamRepository.existsById(teamId)) {
 			String imageUrl = null;
 			if (betsTeam.getImageId() != null) {
-				imageUrl = "https://assets.b365api.com/images/team/m/" + betsTeam.getImageId() + ".png";
+				imageUrl = TEAM_IMAGE_BASE_URL + betsTeam.getImageId() + ".png";
 			}
 
 			Team team = Team.builder()
@@ -200,6 +184,11 @@ public class MatchSyncService {
 	}
 
 	private void saveMatch(BetsEventResponse.Event event, String sportId) {
+		if (event.getLeague() == null || event.getHome() == null || event.getAway() == null) {
+			log.warn("경기 저장 스킵 - 필수 정보 누락 (league/home/away) eventId: {}", event.getId());
+			return;
+		}
+
 		String matchId = Match.generateMatchId(sportId, event.getId());
 
 		Match match = matchRepository.findById(matchId)
@@ -215,7 +204,7 @@ public class MatchSyncService {
 		// 시작 시간
 		if (event.getTime() != null) {
 			long timestamp = Long.parseLong(event.getTime());
-			match.setStartAt(LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp), ZoneId.of("Asia/Seoul")));
+			match.setStartAt(LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp), DEFAULT_ZONE_ID));
 		}
 
 		// 스코어

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchSyncService.java
@@ -3,6 +3,7 @@ package com.scorenow.scorenow_api.domain.match.service;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 import org.springframework.stereotype.Service;
 
@@ -35,6 +36,10 @@ public class MatchSyncService {
 	 */
 	@Transactional
 	public int syncUpcomingMatches(String sportId, String day) {
+		if (day == null) {
+			day = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+		}
+
 		log.info("예정 경기 동기화 시작 - sportsId: {}, day: {}", sportId, day);
 
 		int totalSynced = 0;
@@ -99,6 +104,10 @@ public class MatchSyncService {
 	 */
 	@Transactional
 	public int syncEndedMatches(String sportId, String day) {
+		if (day == null) {
+			day = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+		}
+
 		log.info("종료 경기 동기화 시작 - sportId: {}, day: {}", sportId, day);
 
 		int totalSynced = 0;
@@ -193,13 +202,8 @@ public class MatchSyncService {
 	private void saveMatch(BetsEventResponse.Event event, String sportId) {
 		String matchId = Match.generateMatchId(sportId, event.getId());
 
-		Match match = matchRepository.findById(matchId).orElse(
-			Match.builder()
-				.id(matchId)
-				.betsApiEventId(event.getId())
-				.bet365Id(event.getBet365Id())
-				.build()
-		);
+		Match match = matchRepository.findById(matchId)
+			.orElse(Match.builder().id(matchId).betsApiEventId(event.getId()).bet365Id(event.getBet365Id()).build());
 
 		// 기본 정보 업데이트
 		match.setSportId(sportId);
@@ -211,10 +215,7 @@ public class MatchSyncService {
 		// 시작 시간
 		if (event.getTime() != null) {
 			long timestamp = Long.parseLong(event.getTime());
-			match.setStartAt(LocalDateTime.ofInstant(
-				Instant.ofEpochSecond(timestamp),
-				ZoneId.of("Asia/Seoul")
-			));
+			match.setStartAt(LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp), ZoneId.of("Asia/Seoul")));
 		}
 
 		// 스코어

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchSyncService.java
@@ -1,0 +1,233 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.springframework.stereotype.Service;
+
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueRepository;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+import com.scorenow.scorenow_api.domain.match.repository.MatchRepository;
+import com.scorenow.scorenow_api.domain.team.entity.Team;
+import com.scorenow.scorenow_api.domain.team.repository.TeamRepository;
+import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsEventResponse;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MatchSyncService {
+
+	private final BetsApiClient betsApiClient;
+	private final MatchRepository matchRepository;
+	private final LeagueRepository leagueRepository;
+	private final TeamRepository teamRepository;
+
+	/**
+	 * 예정 경기 동기화
+	 */
+	@Transactional
+	public int syncUpcomingMatches(String sportId, String day) {
+		log.info("예정 경기 동기화 시작 - sportsId: {}, day: {}", sportId, day);
+
+		int totalSynced = 0;
+		int page = 1;
+
+		while (page <= 10) {
+			BetsEventResponse response = betsApiClient.getUpcomingEvents(sportId, day, page);
+
+			if (response == null || response.getResults() == null || response.getResults().isEmpty()) {
+				break;
+			}
+
+			for (BetsEventResponse.Event event : response.getResults()) {
+				try {
+					syncEvent(event, sportId);
+					totalSynced++;
+				} catch (Exception e) {
+					log.error("경기 동기화 실패 - eventId: {}, error: {}", event.getId(), e.getMessage());
+				}
+			}
+
+			// 다음 페이지 있는지 확인
+			if (response.getResults().size() < 50) {
+				break;
+			}
+			page++;
+		}
+
+		log.info("예정 경기 동기화 완료 - 총 {}건", totalSynced);
+		return totalSynced;
+	}
+
+	/**
+	 * 진행 중 경기 동기화
+	 */
+	@Transactional
+	public int syncInplayMatches(String sportId) {
+		log.info("진행 중 경기 동기화 시작 - sportId: {}", sportId);
+
+		BetsEventResponse response = betsApiClient.getInplayEvents(sportId);
+
+		if (response == null || response.getResults() == null) {
+			return 0;
+		}
+
+		int totalSynced = 0;
+		for (BetsEventResponse.Event event : response.getResults()) {
+			try {
+				syncEvent(event, sportId);
+				totalSynced++;
+			} catch (Exception e) {
+				log.error("경기 동기화 실패 - eventId: {}, error: {}", event.getId(), e.getMessage());
+			}
+		}
+
+		log.info("진행 중 경기 동기화 완료 - 총 {}건", totalSynced);
+		return totalSynced;
+	}
+
+	/**
+	 * 종료 경기 동기화
+	 */
+	@Transactional
+	public int syncEndedMatches(String sportId, String day) {
+		log.info("종료 경기 동기화 시작 - sportId: {}, day: {}", sportId, day);
+
+		int totalSynced = 0;
+		int page = 1;
+
+		while (page <= 10) {
+			BetsEventResponse response = betsApiClient.getEndedEvents(sportId, day, page);
+
+			if (response == null || response.getResults() == null || response.getResults().isEmpty()) {
+				break;
+			}
+
+			for (BetsEventResponse.Event event : response.getResults()) {
+				try {
+					syncEvent(event, sportId);
+					totalSynced++;
+				} catch (Exception e) {
+					log.error("경기 동기화 실패 - eventId: {}, error: {}", event.getId(), e.getMessage());
+				}
+			}
+
+			if (response.getResults().size() < 50) {
+				break;
+			}
+			page++;
+		}
+
+		log.info("종료 경기 동기화 완료 - 총 {}건", totalSynced);
+		return totalSynced;
+	}
+
+	/**
+	 * 개별 경기 동기화
+	 */
+	private void syncEvent(BetsEventResponse.Event event, String sportId) {
+		// 1. 리그 저장
+		saveLeague(event.getLeague(), sportId);
+
+		// 2. 팀 저장
+		saveTeam(event.getHome(), sportId);
+		saveTeam(event.getAway(), sportId);
+
+		// 3. 경기 저장
+		saveMatch(event, sportId);
+	}
+
+	private void saveLeague(BetsEventResponse.League betsLeague, String sportId) {
+		if (betsLeague == null)
+			return;
+
+		String leagueId = League.generateLeagueId(sportId, betsLeague.getId());
+
+		if (!leagueRepository.existsById(leagueId)) {
+			League league = League.builder()
+				.id(leagueId)
+				.sportId(sportId)
+				.eName(betsLeague.getName())
+				.kName(betsLeague.getName())
+				.cc(betsLeague.getCc())
+				.build();
+
+			leagueRepository.save(league);
+			log.debug("리그 저장 - {}", leagueId);
+		}
+	}
+
+	private void saveTeam(BetsEventResponse.Team betsTeam, String sportId) {
+		if (betsTeam == null)
+			return;
+
+		String teamId = Team.generateId(sportId, betsTeam.getId());
+
+		if (!teamRepository.existsById(teamId)) {
+			String imageUrl = null;
+			if (betsTeam.getImageId() != null) {
+				imageUrl = "https://assets.b365api.com/images/team/m/" + betsTeam.getImageId() + ".png";
+			}
+
+			Team team = Team.builder()
+				.id(teamId)
+				.sportId(sportId)
+				.eName(betsTeam.getName())
+				.kName(betsTeam.getName())
+				.cc(betsTeam.getCc())
+				.imageUrl(imageUrl)
+				.build();
+			teamRepository.save(team);
+			log.debug("팀 저장 - {}", teamId);
+		}
+	}
+
+	private void saveMatch(BetsEventResponse.Event event, String sportId) {
+		String matchId = Match.generateMatchId(sportId, event.getId());
+
+		Match match = matchRepository.findById(matchId).orElse(
+			Match.builder()
+				.id(matchId)
+				.betsApiEventId(event.getId())
+				.bet365Id(event.getBet365Id())
+				.build()
+		);
+
+		// 기본 정보 업데이트
+		match.setSportId(sportId);
+		match.setLeagueId(League.generateLeagueId(sportId, event.getLeague().getId()));
+		match.setHomeId(Team.generateId(sportId, event.getHome().getId()));
+		match.setAwayId(Team.generateId(sportId, event.getAway().getId()));
+		match.setStatusCode(MatchStatus.fromCode(event.getTimeStatus()));
+
+		// 시작 시간
+		if (event.getTime() != null) {
+			long timestamp = Long.parseLong(event.getTime());
+			match.setStartAt(LocalDateTime.ofInstant(
+				Instant.ofEpochSecond(timestamp),
+				ZoneId.of("Asia/Seoul")
+			));
+		}
+
+		// 스코어
+		if (event.getSs() != null && event.getSs().contains("-")) {
+			String[] scores = event.getSs().split("-");
+			if (scores.length == 2) {
+				match.setHomeScore(Integer.parseInt(scores[0].trim()));
+				match.setAwayScore(Integer.parseInt(scores[1].trim()));
+			}
+		}
+
+		matchRepository.save(match);
+		log.debug("경기 저장 - {}", matchId);
+	}
+
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchSyncService.java
@@ -62,7 +62,7 @@ public class MatchSyncService {
 			}
 
 			// 다음 페이지 있는지 확인
-			if (response.getResults().size() < 50) {
+			if (response.getResults().size() < response.getPager().getPerPage()) {
 				break;
 			}
 			page++;
@@ -129,7 +129,7 @@ public class MatchSyncService {
 				}
 			}
 
-			if (response.getResults().size() < 50) {
+			if (response.getResults().size() < response.getPager().getPerPage()) {
 				break;
 			}
 			page++;

--- a/src/main/java/com/scorenow/scorenow_api/domain/player/entity/Player.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/player/entity/Player.java
@@ -1,28 +1,32 @@
 package com.scorenow.scorenow_api.domain.player.entity;
 
 import com.scorenow.scorenow_api.global.entity.BaseEntity;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Table(name = "players")
-@Getter @Setter
+@Getter
+@Setter
 @NoArgsConstructor
-public class Player extends BaseEntity{
-    @Id
-    private String id; // BETS + sportId + playerId
+public class Player extends BaseEntity {
+	@Id
+	private String id; // BETS + sportId + playerId
 
-    private String kName;     // 선수 이름
-    private String teamId;   // BETS + sportId + teamId (연관관계 없이 ID만 저장)
-    private String cc; // 국가코드
+	private String kName;     // 선수 이름
+	private String teamId;   // BETS + sportId + teamId (연관관계 없이 ID만 저장)
+	private String cc; // 국가코드
 
-    private String eName;     // 영문 이름
-    private String backNumber; // 등번호
+	private String eName;     // 영문 이름
+	private String backNumber; // 등번호
 
-    private String birthDate; // 생년월일
-    private Double height;    // 신장(cm)
+	private String birthDate; // 생년월일
+	private Double height;    // 신장(cm)
 
-    private boolean isInSquad;  // 팀 스쿼드 등록 여부
+	private boolean isInSquad;  // 팀 스쿼드 등록 여부
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/sport/entity/Sport.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/sport/entity/Sport.java
@@ -1,20 +1,29 @@
 package com.scorenow.scorenow_api.domain.sport.entity;
 
 import com.scorenow.scorenow_api.global.entity.BaseEntity;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-
 @Entity
 @Table(name = "sports")
-@Getter @Setter
+@Getter
+@Setter
 @NoArgsConstructor
-public class Sport extends BaseEntity{
-    @Id
-    private String id;
-    private String kName;
-    private String eName;
+@AllArgsConstructor
+@Builder
+public class Sport extends BaseEntity {
+	@Id
+	private String id;
+	private String kName;
+	private String eName;
 
+	@Builder.Default
+	private boolean isActive = true;
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/sport/repository/SportRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/sport/repository/SportRepository.java
@@ -1,0 +1,8 @@
+package com.scorenow.scorenow_api.domain.sport.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.scorenow.scorenow_api.domain.sport.entity.Sport;
+
+public interface SportRepository extends JpaRepository<Sport, String> {
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/team/entity/Team.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/team/entity/Team.java
@@ -1,23 +1,39 @@
 package com.scorenow.scorenow_api.domain.team.entity;
 
 import com.scorenow.scorenow_api.global.entity.BaseEntity;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Table(name = "teams")
-@Getter @Setter
+@Getter
+@Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Team extends BaseEntity {
-    @Id
-    private String id; // BETS + sportId + teamId
-    private String type;    // 구분 (국가대표, 클럽)
-    private String kName;
-    private String eName;
-    private String sName; // 숏네임
-    private String sportId;
-    private String cc; // 국가코드
-    private String imageUrl;
+	@Id
+	private String id; // BETS + sportId + teamId
+	private String type;    // 구분 (국가대표, 클럽)
+	private String kName;
+	private String eName;
+	private String sName; // 숏네임
+	private String sportId;
+	private String cc; // 국가코드
+	private String imageUrl;
+
+	@Builder.Default
+	private boolean isActive = true;
+
+	public static String generateId(String sportId, String teamId) {
+		return "BETS" + sportId + teamId;
+	}
+
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/team/repository/TeamRepository.java
@@ -1,0 +1,8 @@
+package com.scorenow.scorenow_api.domain.team.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.scorenow.scorenow_api.domain.team.entity.Team;
+
+public interface TeamRepository extends JpaRepository<Team, String> {
+}

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/BetsApiClient.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/BetsApiClient.java
@@ -22,7 +22,7 @@ public class BetsApiClient {
 	/**
 	 * 예정 경기 조회
 	 */
-	public BetsEventResponse getUpcomingEvents(String sportId, String day, int page){
+	public BetsEventResponse getUpcomingEvents(String sportId, String day, int page) {
 		String url = buildUrl("/v3/events/upcoming")
 			.queryParam("sport_id", sportId)
 			.queryParamIfPresent("day", java.util.Optional.ofNullable(day))
@@ -36,7 +36,7 @@ public class BetsApiClient {
 	/**
 	 * 진행 중 경기 조회
 	 */
-	public BetsEventResponse getInplayEvents(String sportId){
+	public BetsEventResponse getInplayEvents(String sportId) {
 		String url = buildUrl("/v3/events/inplay")
 			.queryParam("sport_id", sportId)
 			.build().toUriString();
@@ -48,7 +48,7 @@ public class BetsApiClient {
 	/**
 	 * 종료 경기 조회
 	 */
-	public BetsEventResponse getEndedEvents(String sportId, String day, int page){
+	public BetsEventResponse getEndedEvents(String sportId, String day, int page) {
 		String url = buildUrl("/v3/events/ended")
 			.queryParam("sport_id", sportId)
 			.queryParamIfPresent("day", java.util.Optional.ofNullable(day))
@@ -62,7 +62,7 @@ public class BetsApiClient {
 	/**
 	 * 리그 목록 조회
 	 */
-	public BetsLeagueResponse getLeagues(String sportId, int page){
+	public BetsLeagueResponse getLeagues(String sportId, int page) {
 		String url = buildUrl("/v4/league")
 			.queryParam("sport_id", sportId)
 			.queryParam("page", page)
@@ -75,7 +75,7 @@ public class BetsApiClient {
 	/**
 	 * 팀 목록 조회
 	 */
-	public BetsTeamResponse getTeams(String sportId, String maxId){
+	public BetsTeamResponse getTeams(String sportId, String maxId) {
 		String url = buildUrl("/v3/team")
 			.queryParam("sport_id", sportId)
 			.queryParamIfPresent("max_id", java.util.Optional.ofNullable(maxId))
@@ -88,7 +88,7 @@ public class BetsApiClient {
 	/**
 	 * URL 빌더(공통)
 	 */
-	private UriComponentsBuilder buildUrl(String path){
+	private UriComponentsBuilder buildUrl(String path) {
 		return UriComponentsBuilder
 			.fromHttpUrl(properties.getBaseUrl())
 			.path(path)
@@ -98,7 +98,7 @@ public class BetsApiClient {
 	/**
 	 * 로그에 토큰 노출 방지
 	 */
-	private String maskToken(String url){
+	private String maskToken(String url) {
 		return url.replaceAll("token=[^&]+", "token=***");
 	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/controller/BetsApiTestController.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/controller/BetsApiTestController.java
@@ -1,5 +1,6 @@
 package com.scorenow.scorenow_api.external.betsapi.controller;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +14,7 @@ import com.scorenow.scorenow_api.global.dto.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 
+@Profile({"dev", "test"})
 @RestController
 @RequestMapping("/api/test/betsapi")
 @RequiredArgsConstructor

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/controller/BetsApiTestController.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/controller/BetsApiTestController.java
@@ -1,24 +1,25 @@
 package com.scorenow.scorenow_api.external.betsapi.controller;
 
-import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.scorenow.scorenow_api.domain.match.service.MatchSyncService;
 import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsEventResponse;
 import com.scorenow.scorenow_api.global.dto.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 
-@Profile({"dev", "test"})
 @RestController
 @RequestMapping("/api/test/betsapi")
 @RequiredArgsConstructor
 public class BetsApiTestController {
 
 	private final BetsApiClient betsApiClient;
+	private final MatchSyncService matchSyncService;
 
 	@GetMapping("/upcoming")
 	public ApiResponse<BetsEventResponse> testUpcoming(
@@ -34,5 +35,31 @@ public class BetsApiTestController {
 		@RequestParam(defaultValue = "1") String sportId) {
 
 		return ApiResponse.success(betsApiClient.getInplayEvents(sportId));
+	}
+
+	@PostMapping("/sync/upcoming")
+	public ApiResponse<String> syncUpcoming(
+		@RequestParam(defaultValue = "1") String sportId,
+		@RequestParam(required = false) String day
+	) {
+		int count = matchSyncService.syncUpcomingMatches(sportId, day);
+		return ApiResponse.success(count + "건 동기화 완료");
+	}
+
+	@PostMapping("/sync/inplay")
+	public ApiResponse<String> syncInplay(
+		@RequestParam(defaultValue = "1") String sportId
+	) {
+		int count = matchSyncService.syncInplayMatches(sportId);
+		return ApiResponse.success(count + "건 동기화 완료");
+	}
+
+	@PostMapping("/sync/ended")
+	public ApiResponse<String> syncEnded(
+		@RequestParam(defaultValue = "1") String sportId,
+		@RequestParam(required = false) String day
+	) {
+		int count = matchSyncService.syncEndedMatches(sportId, day);
+		return ApiResponse.success(count + "건 동기화 완료");
 	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsEventResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsEventResponse.java
@@ -12,10 +12,11 @@ import lombok.Setter;
 public class BetsEventResponse {
 	private int success;
 	private BetsPager pager;
+	private List<Event> results;
 
 	@Getter
 	@Setter
-	public static class Event{
+	public static class Event {
 		private String id;
 
 		@JsonProperty("sport_id")
@@ -37,7 +38,7 @@ public class BetsEventResponse {
 
 	@Getter
 	@Setter
-	public static class League{
+	public static class League {
 		private String id;
 		private String name;
 		private String cc;
@@ -45,7 +46,7 @@ public class BetsEventResponse {
 
 	@Getter
 	@Setter
-	public static class Team{
+	public static class Team {
 		private String id;
 		private String name;
 

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsLeagueResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsLeagueResponse.java
@@ -14,7 +14,7 @@ public class BetsLeagueResponse {
 
 	@Getter
 	@Setter
-	public static class League{
+	public static class League {
 		private String id;
 		private String name;
 		private String cc;

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsTeamResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsTeamResponse.java
@@ -16,7 +16,7 @@ public class BetsTeamResponse {
 
 	@Getter
 	@Setter
-	public static class Team{
+	public static class Team {
 		private String id;
 		private String name;
 

--- a/src/main/java/com/scorenow/scorenow_api/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/config/RestTemplateConfig.java
@@ -11,7 +11,8 @@ import org.springframework.web.client.RestTemplate;
 public class RestTemplateConfig {
 
 	@Bean
-	public RestTemplate restTemplate(RestTemplateBuilder builder, com.scorenow.scorenow_api.external.betsapi.BetsApiProperties properties){
+	public RestTemplate restTemplate(RestTemplateBuilder builder,
+		com.scorenow.scorenow_api.external.betsapi.BetsApiProperties properties) {
 		return builder
 			.setConnectTimeout(Duration.ofSeconds(properties.getConnectTimeout()))
 			.setReadTimeout(Duration.ofSeconds(properties.getReadTimeout()))

--- a/src/main/java/com/scorenow/scorenow_api/global/dto/ApiResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/dto/ApiResponse.java
@@ -10,22 +10,14 @@ import lombok.Getter;
 @Getter
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ApiResponse<T>{
+public class ApiResponse<T> {
 	private final boolean success;
 	private final T data;
 	private final ErrorDetail error;
 	private final LocalDateTime timestamp;
 
-	@Getter
-	@Builder
-	public static class ErrorDetail{
-		private final String code;
-		private final String message;
-		private final Object details;
-	}
-
 	// 성공 응답(데이터 있음)
-	public static <T> ApiResponse<T> success(T data){
+	public static <T> ApiResponse<T> success(T data) {
 		return ApiResponse.<T>builder()
 			.success(true)
 			.data(data)
@@ -35,17 +27,17 @@ public class ApiResponse<T>{
 	}
 
 	// 성공 응답(데이터 없음)
-	public static <T> ApiResponse<T> success(){
-		return  success(null);
+	public static <T> ApiResponse<T> success() {
+		return success(null);
 	}
 
 	// 에러 응답
-	public static <T> ApiResponse<T> error(String code, String message){
+	public static <T> ApiResponse<T> error(String code, String message) {
 		return error(code, message, null);
 	}
 
 	// 에러응답(상세 정보 포함)
-	public static <T> ApiResponse<T> error(String code, String message, Object details){
+	public static <T> ApiResponse<T> error(String code, String message, Object details) {
 		return ApiResponse.<T>builder()
 			.success(false)
 			.data(null)
@@ -56,5 +48,13 @@ public class ApiResponse<T>{
 				.build())
 			.timestamp(LocalDateTime.now())
 			.build();
+	}
+
+	@Getter
+	@Builder
+	public static class ErrorDetail {
+		private final String code;
+		private final String message;
+		private final Object details;
 	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/global/entity/BaseEntity.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/entity/BaseEntity.java
@@ -1,24 +1,25 @@
 package com.scorenow.scorenow_api.global.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
-import lombok.Getter;
+import java.time.LocalDateTime;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdAt;
 
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/scorenow/scorenow_api/global/exception/BusinessException.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/exception/BusinessException.java
@@ -3,24 +3,24 @@ package com.scorenow.scorenow_api.global.exception;
 import lombok.Getter;
 
 @Getter
-public class BusinessException extends RuntimeException{
+public class BusinessException extends RuntimeException {
 
 	private final ErrorCode errorCode;
 	private final Object details;
 
-	public BusinessException(ErrorCode errorCode){
+	public BusinessException(ErrorCode errorCode) {
 		this(errorCode, errorCode.getMessage(), null);
 	}
 
-	public BusinessException(ErrorCode errorCode, String message){
+	public BusinessException(ErrorCode errorCode, String message) {
 		this(errorCode, message, null);
 	}
 
-	public BusinessException(ErrorCode errorCode, Object details){
+	public BusinessException(ErrorCode errorCode, Object details) {
 		this(errorCode, errorCode.getMessage(), details);
 	}
 
-	public BusinessException(ErrorCode errorCode, String message, Object details){
+	public BusinessException(ErrorCode errorCode, String message, Object details) {
 		super(message);
 		this.errorCode = errorCode;
 		this.details = details;

--- a/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
@@ -15,9 +15,7 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 내부 오류가 발생했습니다."),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C004", "지원하지 않는 HTTP 메서드입니다");
 
-
 	// Match
-
 
 	// Team
 

--- a/src/main/java/com/scorenow/scorenow_api/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/exception/GlobalExceptionHandler.java
@@ -51,7 +51,7 @@ public class GlobalExceptionHandler {
 	 * BusinessException 처리
 	 */
 	@ExceptionHandler(BusinessException.class)
-	public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e){
+	public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
 		log.warn("BusinessException: {}", e.getErrorCode().getCode());
 
 		ErrorCode errorCode = e.getErrorCode();
@@ -70,12 +70,12 @@ public class GlobalExceptionHandler {
 	 * Validation 예외 처리(@Valid)
 	 */
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e){
+	public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
 		log.warn("Validation failed for {} fields", e.getBindingResult().getErrorCount());
 
 		Map<String, String> errors = new HashMap<>();
 		e.getBindingResult().getAllErrors().forEach(error -> {
-			String fieldName = error instanceof FieldError ? ((FieldError) error).getField() : error.getObjectName();
+			String fieldName = error instanceof FieldError ? ((FieldError)error).getField() : error.getObjectName();
 			errors.put(fieldName, error.getDefaultMessage());
 		});
 
@@ -94,7 +94,8 @@ public class GlobalExceptionHandler {
 	 * 필수 파라미터 누락 처리
 	 */
 	@ExceptionHandler(MissingServletRequestParameterException.class)
-	public ResponseEntity<ApiResponse<Void>> handleMissingParameterException(MissingServletRequestParameterException e){
+	public ResponseEntity<ApiResponse<Void>> handleMissingParameterException(
+		MissingServletRequestParameterException e) {
 		log.warn("Missing parameter: {}", e.getParameterName());
 
 		Map<String, String> details = Map.of(e.getParameterName(), "필수 파라미터가 누락되었습니다.");
@@ -134,7 +135,8 @@ public class GlobalExceptionHandler {
 	 * 지원하지 않는 HTTP Method 처리
 	 */
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-	public ResponseEntity<ApiResponse<Void>> handleMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+	public ResponseEntity<ApiResponse<Void>> handleMethodNotSupportedException(
+		HttpRequestMethodNotSupportedException e) {
 		log.warn("Method not supported: {}", e.getMethod());
 
 		ApiResponse<Void> response = ApiResponse.error(


### PR DESCRIPTION
## #️⃣ Issue Number
> Closed #6 

## 📝 요약(Summary)
> BetsAPI 경기 데이터를 DB에 동기화

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 아직 스케줄러 구현은 안했습니다 저희가 로컬로 실행하느라 읻단 스케줄러 의미가 없을거 같아 수동 controller로 했습니다.
- 이후에 스케줄러 구현 + 배포가 완료되면 수동 controller 부분은 삭제하겠습니다.
- 아직 개발하면서 테이블 구조가 좀 바뀔수 있을거 같아 나중에 배포 전에 migration 파일 만드는게 좋을 것 같습니다
- 각 리그, 팀, 경기 엔티티마다 저희 ID 생성규칙 적용해서 만들었습니다.
- 그리고 upcoming과 ended에는 데이터가 많아 당일로 제한시키고 나중에 스케줄링을 더 타이트하게 해서 불러오면 될 것 같습니다.
- inplay는 페이지가 없는걸로 알고 있고 upcoming과 ended는 일단 기본값 10으로 설정했습니다. 이거는 단계적으로 숫자를 늘리면 될 것 같습니다.
- 다음 이슈에서는 매치 동기화 끝났으니 팀과 리그 데이터 진행 예정입니다.
- 팀쪽 imgurl은 betsapi 형식에 맞춰서 커스텀했습니다.
- upcoming과 ended 모두 페이지당 50개로 알고 있지만 하드코딩보다는 api에서 반환해주는 page값을 추출하는 방식으로 했습니다.
- 포맷팅 적용하는 방법을 몰랐었는데 이번 pr에 전부 포맷팅 적용해서 올립니다.

## Gemin Code review 반영 결과
- syncUpcoming과 syncEnded 중복 로직이 발생해 private 공통 메서드로 뺐습니다.
- 보니까 BiFunction이라는 자바에서 제공해주는 인터페이스가 있던데 입력을 2개로 받으면 1개로 출력해주는 기능 같습니다.
- 저희는 BiFunction<String, Integer, BetsEventResponse>로 day + page-> API 응답만 받도록 설정했습니다.
- 상수 관련 코드가 지금은 적은데 나중에 많아지면 config 폴더로 뺄 것 같습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
