### PR TITLE
feat: 라인업 수동 동기화 및 저장

### DIFF
--- a/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchLineupController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchLineupController.java
@@ -1,0 +1,40 @@
+package com.scorenow.scorenow_api.domain.match.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.scorenow.scorenow_api.domain.match.document.MatchLineupDocument;
+import com.scorenow.scorenow_api.domain.match.service.MatchLineupService;
+import com.scorenow.scorenow_api.global.dto.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/lineup")
+public class MatchLineupController {
+
+	private final MatchLineupService matchLineupSvc;
+
+	/**
+	 * eventId를 직접 넣어서 라인업 호출 + Mongo 저장
+	 * POST /api/lineup/save?eventId=10119802
+	 */
+	@PostMapping("/save")
+	public ApiResponse<MatchLineupDocument> saveLineup(@RequestParam String eventId) {
+		return ApiResponse.success(matchLineupSvc.fetchAndSaveByEventId(eventId));
+	}
+
+	/**
+	 * 저장된 라인업 조회 (Mongo)
+	 * GET /api/lineup/{matchId}
+	 */
+	@GetMapping("/{matchId}")
+	public ApiResponse<MatchLineupDocument> getLineup(@PathVariable String matchId) {
+		return ApiResponse.success(matchLineupSvc.getByMatchId(matchId));
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/document/MatchLineupDocument.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/document/MatchLineupDocument.java
@@ -1,0 +1,31 @@
+package com.scorenow.scorenow_api.domain.match.document;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.scorenow.scorenow_api.domain.match.model.LineupSide;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "match_lineups")
+public class MatchLineupDocument {
+
+	@Id
+	private String id; // matchId
+
+	private LineupSide home;
+	private LineupSide away;
+
+	public static MatchLineupDocument create(String matchId) {
+		MatchLineupDocument doc = new MatchLineupDocument();
+		doc.id = matchId;
+		return doc;
+	}
+}
+

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/model/LineupPlayer.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/model/LineupPlayer.java
@@ -1,0 +1,28 @@
+package com.scorenow.scorenow_api.domain.match.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class LineupPlayer {
+
+	private String rowId;
+	private String playerId;
+	private String eName;
+	private String kName;
+
+	private Integer shirtNumber;
+	private String position;
+	private Integer goals;
+
+	private boolean substitute;  // startinglineup=false, substitute=true
+	private boolean temp;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/model/LineupSide.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/model/LineupSide.java
@@ -1,0 +1,29 @@
+package com.scorenow.scorenow_api.domain.match.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class LineupSide {
+
+	private String teamId;
+	private String formation;
+	private String uniformColor;
+
+	@Builder.Default
+	private List<LineupPlayer> startingLineup = new ArrayList<>();
+
+	@Builder.Default
+	private List<LineupPlayer> substitutes = new ArrayList<>();
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/MatchLineupRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/MatchLineupRepository.java
@@ -1,0 +1,8 @@
+package com.scorenow.scorenow_api.domain.match.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import com.scorenow.scorenow_api.domain.match.document.MatchLineupDocument;
+
+public interface MatchLineupRepository extends MongoRepository<MatchLineupDocument, String> {
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupService.java
@@ -1,0 +1,140 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.scorenow.scorenow_api.domain.match.document.MatchLineupDocument;
+import com.scorenow.scorenow_api.domain.match.model.LineupPlayer;
+import com.scorenow.scorenow_api.domain.match.model.LineupSide;
+import com.scorenow.scorenow_api.domain.match.repository.MatchLineupRepository;
+import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsLineupResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MatchLineupService {
+
+	private final BetsApiClient betsApiClient;
+	private final MatchLineupRepository matchLineupRepository;
+
+	/**
+	 * eventId 기준으로 라인업 조회 + Mongo 저장 (upsert)
+	 * matchId 예: BETS1 + eventId
+	 */
+	@Transactional
+	public MatchLineupDocument fetchAndSaveByEventId(String eventId) {
+		if (eventId == null || eventId.isBlank()) {
+			throw new IllegalArgumentException("eventId is blank");
+		}
+
+		String matchId = "BETS1" + eventId;
+
+		BetsLineupResponse response = betsApiClient.getLineup(eventId);
+		validateResponse(response, eventId);
+
+		BetsLineupResponse.BetsLineupResult results = response.getResults();
+
+		MatchLineupDocument doc = matchLineupRepository.findById(matchId)
+			.orElseGet(() -> MatchLineupDocument.create(matchId));
+
+		doc.setHome(mapSide(results.getHome()));
+		doc.setAway(mapSide(results.getAway()));
+
+		return matchLineupRepository.save(doc);
+	}
+
+	@Transactional(readOnly = true)
+	public MatchLineupDocument getByMatchId(String matchId) {
+		return matchLineupRepository.findById(matchId)
+			.orElseThrow(() -> new IllegalArgumentException("라인업이 존재하지 않습니다. matchId=" + matchId));
+	}
+
+	/* ========== */
+	private void validateResponse(BetsLineupResponse response, String eventId) {
+		if (response == null) {
+			throw new IllegalStateException("라인업 API 응답이 null 입니다. eventId=" + eventId);
+		}
+		if (response.getSuccess() == null || response.getSuccess() != 1) {
+			throw new IllegalStateException("라인업 API 실패. success=" + response.getSuccess() + ", eventId=" + eventId);
+		}
+		if (response.getResults() == null
+			|| response.getResults().getHome() == null
+			|| response.getResults().getAway() == null) {
+			throw new IllegalStateException("라인업 API results/home/away가 비어있습니다. eventId=" + eventId);
+		}
+	}
+
+	private LineupSide mapSide(BetsLineupResponse.BetsLineupSide ext) {
+		return LineupSide.builder()
+			.formation(ext.getFormation())
+			.startingLineup(mapPlayers(ext.getStartinglineup()))
+			.substitutes(mapPlayers(ext.getSubstitutes()))
+			.build();
+	}
+
+	private List<LineupPlayer> mapPlayers(List<BetsLineupResponse.BetsLineupPlayer> extPlayers) {
+		if (extPlayers == null) {
+			return new ArrayList<>();
+		}
+		List<LineupPlayer> list = new ArrayList<>();
+		for (BetsLineupResponse.BetsLineupPlayer ext : extPlayers) {
+			list.add(mapPlayer(ext));
+		}
+		return list;
+	}
+
+	/* TODO: view api 골득점 업데이트 */
+	private LineupPlayer mapPlayer(BetsLineupResponse.BetsLineupPlayer ext) {
+		String playerId = null;
+		String eName = null;
+
+		if (ext != null && ext.getPlayer() != null) {
+			playerId = ext.getPlayer().getId();
+			eName = ext.getPlayer().getName();
+		}
+
+		return LineupPlayer.builder()
+			.playerId(playerId)
+			.eName(eName)
+			.shirtNumber(parseIntOrNull(ext != null ? ext.getShirtnumber() : null))
+			.position(mapPosition(ext != null ? ext.getPos() : null))
+			.goals(0) // view api 연동 전
+			.build();
+	}
+
+	private Integer parseIntOrNull(String v) {
+		if (v == null || v.isBlank())
+			return null;
+		try {
+			return Integer.valueOf(v);
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private String mapPosition(String pos) {
+		if (pos == null)
+			return null;
+
+		return switch (pos) {
+			case "Guard" -> "GK";
+			case "Defender" -> "DF";
+			case "Midfielder" -> "MF";
+			case "Forward" -> "FW";
+			default -> "SUB";
+		};
+	}
+
+	/* TODO: matchId를 입력으로 받을 때 사용 */
+	private String extractEventId(String matchId) {
+		if (!matchId.startsWith("BETS")) {
+			throw new IllegalArgumentException("Invalid matchId format: " + matchId);
+		}
+		return matchId.replaceFirst("^BETS\\d+", "");
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/BetsApiClient.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/BetsApiClient.java
@@ -1,13 +1,14 @@
 package com.scorenow.scorenow_api.external.betsapi;
 
-import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsEventResponse;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsLeagueResponse;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsLineupResponse;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsTeamResponse;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -91,13 +92,21 @@ public class BetsApiClient {
 	 */
 	public BetsViewResponse getEventView(String eventId) {
 		String url = buildUrl("/v1/event/view")
-				.queryParam("event_id", eventId)
-				.build().toUriString();
+			.queryParam("event_id", eventId)
+			.build().toUriString();
 
 		log.debug("BetsAPI 상세 호출: {}", maskToken(url));
 		return restTemplate.getForObject(url, BetsViewResponse.class);
 	}
 
+	public BetsLineupResponse getLineup(String eventId) {
+		String url = buildUrl("/v4/event/lineup")
+			.queryParam("event_id", eventId)
+			.build().toUriString();
+
+		log.debug("BetsAPI 호출: {}", maskToken(url));
+		return restTemplate.getForObject(url, BetsLineupResponse.class);
+	}
 
 	/**
 	 * URL 빌더(공통)

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsLineupResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsLineupResponse.java
@@ -1,0 +1,47 @@
+package com.scorenow.scorenow_api.external.betsapi.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BetsLineupResponse {
+
+	private Integer success;
+	private BetsLineupResult results;
+
+	@Getter
+	@Setter
+	public static class BetsLineupResult {
+		private BetsLineupSide home;
+		private BetsLineupSide away;
+	}
+
+	@Getter
+	@Setter
+	public static class BetsLineupSide {
+		private String formation;
+		private List<BetsLineupPlayer> startinglineup;
+		private List<BetsLineupPlayer> substitutes;
+	}
+
+	@Getter
+	@Setter
+	public static class BetsLineupPlayer {
+
+		private ExternalPlayer player;
+		private String shirtnumber;
+		private String pos;
+
+		@Getter
+		@Setter
+		public static class ExternalPlayer {
+			private String id;
+			private String name;
+			private String cc;
+		}
+	}
+}
+


### PR DESCRIPTION
## #️⃣ Issue Number

#11 

## 📝 요약(Summary)

- BetsAPI의 라인업 데이터를 eventId 기준으로 수동 호출하여 MongoDB에 저장하는 기능을 추가했습니다.
- 어드민 및 개발 단계에서 라인업 데이터 수동 동기화 API를 제공합니다.
- 골 득점(view api) 연동은 범위에서 제외하고, 추후 별도 기능으로 분리 예정입니다.


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- `extractEventId()` 메서드는 향후 matchId 기반 API 확장 시 사용 예정으로 현재는 미사용 상태입니다.
- 골 득점 및 경기 상세 정보는 View API을 연동해 반영할 예정입니다. 


## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
