### PR TITLE
feat: 경기중 경기 식별 스케줄러 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.1'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.scorenow'
@@ -9,39 +9,39 @@ version = '0.0.1-SNAPSHOT'
 description = 'Demo project for Spring Boot'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'io.projectreactor:reactor-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchLineupController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchLineupController.java
@@ -26,7 +26,7 @@ public class MatchLineupController {
 	 */
 	@PostMapping("/save")
 	public ApiResponse<MatchLineupDocument> saveLineup(@RequestParam String eventId) {
-		return ApiResponse.success(matchLineupSvc.fetchAndSaveByEventId(eventId));
+		return ApiResponse.success(matchLineupSvc.fetchAndSaveByMatchId(eventId));
 	}
 
 	/**

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/InplayMatchDetectionDto.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/InplayMatchDetectionDto.java
@@ -1,0 +1,16 @@
+package com.scorenow.scorenow_api.domain.match.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class InplayMatchDetectionDto {
+	private final String matchId;
+
+	private final String homeId;    // 홈 팀 ID
+	private final String homeName;    // 홈 팀명(영문)
+
+	private final String awayId;
+	private final String awayName;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/InplayMatchDetectionMarked.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/InplayMatchDetectionMarked.java
@@ -1,0 +1,22 @@
+package com.scorenow.scorenow_api.domain.match.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "inplay_match_detection_marked")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InplayMatchDetectionMarked {
+
+	@Id
+	private String matchId;
+
+	public InplayMatchDetectionMarked(String matchId) {
+		this.matchId = matchId;
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/model/LineupSide.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/model/LineupSide.java
@@ -18,6 +18,8 @@ import lombok.Setter;
 public class LineupSide {
 
 	private String teamId;
+	private String teamEname;
+
 	private String formation;
 	private String uniformColor;
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/InplayMatchDetectionMarkedRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/InplayMatchDetectionMarkedRepository.java
@@ -1,0 +1,9 @@
+package com.scorenow.scorenow_api.domain.match.repository.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.scorenow.scorenow_api.domain.match.entity.InplayMatchDetectionMarked;
+
+public interface InplayMatchDetectionMarkedRepository
+	extends JpaRepository<InplayMatchDetectionMarked, String> {
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
@@ -1,13 +1,26 @@
 package com.scorenow.scorenow_api.domain.match.repository.jpa;
 
-
-import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.scorenow.scorenow_api.domain.match.entity.Match;
-
 import java.util.List;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.scorenow.scorenow_api.domain.match.dto.InplayMatchDetectionDto;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+
 public interface MatchRepository extends JpaRepository<Match, String> {
-    List<Match> findByStatusCode(MatchStatus statusCode);
+	List<Match> findByStatusCode(MatchStatus statusCode);
+
+	@Query("""
+			select new com.scorenow.scorenow_api.domain.match.dto.InplayMatchDetectionDto(
+					m.id, h.id, h.eName, a.id, a.eName
+			)
+			from Match m
+			join Team h on h.id = m.homeId
+			join Team a on a.id = m.awayId
+			where m.statusCode = :status and m.isActive = true
+		""")
+	List<InplayMatchDetectionDto> findInplayMatchDtos(@Param("status") MatchStatus status);
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/InplayMatchDetectionScheduler.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/InplayMatchDetectionScheduler.java
@@ -1,0 +1,38 @@
+package com.scorenow.scorenow_api.domain.match.scheduler;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.scorenow.scorenow_api.domain.match.dto.InplayMatchDetectionDto;
+import com.scorenow.scorenow_api.domain.match.service.InplayMatchDetectionService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InplayMatchDetectionScheduler {
+
+	private final InplayMatchDetectionService inplayMatchSvc;
+
+	/**
+	 * IN_PLAY 경기 식별 스케줄러
+	 * DB에서 IN_PLAY 경기 목록을 한 묶음으로 조회
+	 */
+	@Scheduled(fixedDelay = 5000) // 테스트 5초(운영 시 60초)
+	public void run() {
+		List<InplayMatchDetectionDto> newOnes = inplayMatchSvc.getNewInplayMatchesAndMark();
+		log.info("[IN_PLAY NEW] count={}", newOnes.size());
+
+		newOnes.stream().limit(3).forEach(m ->
+			log.info("[IN_PLAY NEW] matchId={}, HOME={}({}) AWAY={}({})",
+				m.getMatchId(),
+				m.getHomeId(), m.getHomeName(),
+				m.getAwayId(), m.getAwayName()
+			)
+		);
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchDetectionService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchDetectionService.java
@@ -1,0 +1,60 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.scorenow.scorenow_api.domain.match.dto.InplayMatchDetectionDto;
+import com.scorenow.scorenow_api.domain.match.entity.InplayMatchDetectionMarked;
+import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.InplayMatchDetectionMarkedRepository;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class InplayMatchDetectionService {
+
+	private final MatchRepository matchRepo;
+	private final InplayMatchDetectionMarkedRepository markedRepo;
+
+	/** 전체 IN_PLAY MATCHES 조회 */
+	@Transactional(readOnly = true)
+	public List<InplayMatchDetectionDto> getInplayMatches() {
+
+		return matchRepo.findInplayMatchDtos(MatchStatus.IN_PLAY);
+	}
+
+	/** 신규 IN_PLAY MATCHES 조회 */
+	@Transactional
+	public List<InplayMatchDetectionDto> getNewInplayMatchesAndMark() {
+		List<InplayMatchDetectionDto> inplay = matchRepo.findInplayMatchDtos(MatchStatus.IN_PLAY);
+		if (inplay.isEmpty())
+			return List.of();
+
+		List<String> ids = inplay.stream()
+			.map(InplayMatchDetectionDto::getMatchId)
+			.toList();
+
+		Set<String> markedIds = markedRepo.findAllById(ids).stream()
+			.map(InplayMatchDetectionMarked::getMatchId)
+			.collect(Collectors.toSet());
+
+		List<InplayMatchDetectionDto> newOnes = inplay.stream()
+			.filter(dto -> !markedIds.contains(dto.getMatchId()))
+			.toList();
+
+		if (!newOnes.isEmpty()) {
+			List<InplayMatchDetectionMarked> toSave = newOnes.stream()
+				.map(dto -> new InplayMatchDetectionMarked(dto.getMatchId()))
+				.toList();
+			markedRepo.saveAll(toSave);
+		}
+
+		return newOnes;
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupService.java
@@ -27,12 +27,12 @@ public class MatchLineupService {
 	 * matchId 예: BETS1 + eventId
 	 */
 	@Transactional
-	public MatchLineupDocument fetchAndSaveByEventId(String eventId) {
-		if (eventId == null || eventId.isBlank()) {
-			throw new IllegalArgumentException("eventId is blank");
+	public MatchLineupDocument fetchAndSaveByMatchId(String matchId) {
+		if (matchId == null || matchId.isBlank()) {
+			throw new IllegalArgumentException("matchId is blank");
 		}
 
-		String matchId = "BETS1" + eventId;
+		String eventId = extractEventId(matchId);
 
 		BetsLineupResponse response = betsApiClient.getLineup(eventId);
 		validateResponse(response, eventId);
@@ -130,7 +130,6 @@ public class MatchLineupService {
 		};
 	}
 
-	/* TODO: matchId를 입력으로 받을 때 사용 */
 	private String extractEventId(String matchId) {
 		if (!matchId.startsWith("BETS")) {
 			throw new IllegalArgumentException("Invalid matchId format: " + matchId);


### PR DESCRIPTION
## #️⃣ Issue Number
#20

## 📝 요약(Summary)
경기중인 경기 목록을 주기적으로 조회해 신규 경기만 감지하고, 중복 감지를 막기 위해 inplay_match_detection_marked 테이블에 마킹 저장하도록 구현했습니다. 

## 🛠️ PR 유형
- [x] 새로운 기능 추가

## 💬 공유사항 to 리뷰어
findInplayMatchDto() 는 홈/원정 팀 이름을 위해 Team과 Inner Join을 사용하고 있습니다. teams에 데이터가 없는 경기는 DTO 조회 결과에서 제외됩니다. 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
