### PR TITLE
✨Feat: 경기 Admin API 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,6 @@ Java 17 필수. QueryDSL Q-class는 `build/generated/querydsl`에 생성된다.
 - **Lombok:** `@Getter`, `@Builder`, `@NoArgsConstructor` 등 적극 사용
 
 ## API Endpoints
-1
 관리자 API: `/api/admin/matches` (CRUD)
 Swagger UI: `/swagger-ui/index.html`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Score Now Server는 BetsAPI를 통해 실시간 축구 경기 데이터를 수집·관리하는 Spring Boot REST API 서버다. MySQL(관계형), MongoDB(문서형), Redis(캐시)를 함께 사용한다.
+
+## Build & Run Commands
+
+```bash
+./gradlew clean build          # 빌드 (QueryDSL Q-class 자동 생성)
+./gradlew bootRun              # 서버 실행 (localhost:8080)
+./gradlew test                 # 전체 테스트
+./gradlew test --tests "com.scorenow.scorenow_api.SomeTest"  # 단일 테스트
+docker-compose up -d           # 인프라 실행 (MySQL:3306, MongoDB:27017, Redis:6380)
+```
+
+Java 17 필수. QueryDSL Q-class는 `build/generated/querydsl`에 생성된다.
+
+## Architecture
+
+**패키지 구조:** `com.scorenow.scorenow_api`
+
+- `domain/{도메인}/` — 도메인별로 controller, service, repository, entity, dto 계층 분리
+- `external/betsapi/` — BetsAPI 외부 연동 클라이언트 (`BetsApiClient`)
+- `global/` — 공통 설정(config), 예외처리(exception), 베이스 엔티티, 상수
+
+**핵심 도메인:** match, league, team, sport, player
+
+**데이터 저장 전략:**
+- **MySQL (JPA):** Match, League, Team, Sport, Player 등 관계형 엔티티
+- **MongoDB:** MatchDetailDocument(경기 상세 통계), MatchLineupDocument(라인업)
+- **Redis:** 리액티브 캐시
+
+**엔티티 ID 규칙:** `"BETS" + sportId + externalId` 형식 (예: BETS111275660)
+
+**스케줄러:** `@EnableScheduling` 활성화. InplayMatchDetectionScheduler(경기 시작 감지), MatchDetailScheduler(경기 상세 동기화)
+
+## Key Patterns
+
+- **API 응답:** 모든 엔드포인트는 `ApiResponse<T>`로 래핑 (`{success, data/error, timestamp}`)
+- **예외처리:** `ErrorCode` enum → `BusinessException` → `GlobalExceptionHandler`에서 일괄 처리. 에러 메시지는 한국어
+- **QueryDSL:** 복잡한 검색 조건은 `MatchRepositoryCustom` + `MatchRepositoryImpl`로 구현
+- **BaseEntity:** `createdAt`, `updatedAt` 자동 관리 (JPA Auditing)
+- **Lombok:** `@Getter`, `@Builder`, `@NoArgsConstructor` 등 적극 사용
+
+## API Endpoints
+1
+관리자 API: `/api/admin/matches` (CRUD)
+Swagger UI: `/swagger-ui/index.html`
+
+## Configuration
+
+`application.yml`에서 DB 접속 정보, BetsAPI 토큰/타임아웃 등 설정. Spring Security는 Swagger 경로만 공개, 나머지는 인증 필요 (현재 SecurityAutoConfiguration exclude 상태).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,132 @@
+# ⚽ Score Now Server
+
+> **실시간 축구 경기 데이터 수집 및 관리 REST API 서버**
+> BetsAPI 연동을 통해 경기 일정, 실시간 스코어, 경기 상세 통계, 라인업 데이터를 수집·저장·제공합니다.
+
+---
+
+## 🛠️ Tech Stack
+
+### 🧩 Backend
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot%203.3-6DB33F?style=flat&logo=springboot&logoColor=white)
+![Java](https://img.shields.io/badge/Java%2017-007396?style=flat&logo=openjdk&logoColor=white)
+![Spring Batch](https://img.shields.io/badge/Spring%20Batch-6DB33F?style=flat&logo=spring&logoColor=white)
+![Spring Security](https://img.shields.io/badge/Spring%20Security-6DB33F?style=flat&logo=springsecurity&logoColor=white)
+![QueryDSL](https://img.shields.io/badge/QueryDSL-0769AD?style=flat&logo=java&logoColor=white)
+![Swagger](https://img.shields.io/badge/Swagger-85EA2D?style=flat&logo=swagger&logoColor=black)
+
+### 🗄️ Database
+![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=flat&logo=mysql&logoColor=white)
+![MongoDB](https://img.shields.io/badge/MongoDB-47A248?style=flat&logo=mongodb&logoColor=white)
+![Redis](https://img.shields.io/badge/Redis-FF4438?style=flat&logo=redis&logoColor=white)
+
+### ☁️ Infrastructure / DevOps
+
+
+---
+
+## 📐 Architecture
+
+```
+com.scorenow.scorenow_api
+├── domain
+│   ├── match       # 경기 (엔티티, 서비스, 배치, 스케줄러, DTO)
+│   ├── league      # 리그
+│   ├── team        # 팀
+│   ├── player      # 선수
+│   └── sport       # 종목
+├── external
+│   └── betsapi     # BetsAPI 외부 연동 클라이언트
+└── global
+    ├── config      # 공통 설정 (DB, Redis, Batch, Security)
+    ├── exception   # 예외처리 (ErrorCode, BusinessException, GlobalExceptionHandler)
+    └── constant    # 공통 상수
+```
+
+**데이터 저장 전략**
+
+| 저장소 | 용도 |
+|--------|------|
+| MySQL (JPA) | Match, League, Team, Sport, Player 관계형 데이터 |
+| MongoDB | MatchDetailDocument (통계), MatchLineupDocument (라인업) |
+| Redis | 리그·팀 데이터 캐시 |
+
+---
+
+## ⚙️ Initial Settings
+
+### 사전 요구사항
+- Java 17
+- Docker & Docker Compose
+
+### 1. 저장소 클론
+```bash
+git clone https://github.com/your-org/score-now-server.git
+cd score-now-server
+```
+
+### 2. 인프라 실행 (MySQL, MongoDB, Redis)
+```bash
+docker-compose up -d
+```
+
+### 3. 환경 변수 설정
+`src/main/resources/application.yml`에서 BetsAPI 토큰 및 DB 접속 정보를 설정합니다.
+
+### 4. 서버 실행
+```bash
+./gradlew bootRun
+```
+
+### 5. API 문서 확인
+```
+http://localhost:8080/swagger-ui/index.html
+```
+
+---
+
+## 💻 Coding Convention
+
+### 🔀 Git Flow
+1. Issue 생성
+2. Issue 기준으로 Branch 생성
+3. 개발 진행 → `add` → `commit` → `push`
+4. Pull Request 생성
+5. 팀원 Code Review 진행
+6. Review 완료 후 Merge
+
+
+### 🌿 Branch Naming Convention
+> 형식: `{type}/#{이슈번호}`
+```
+feat/#24
+fix/#31
+```
+
+### 💬 Commit Message Convention
+> 형식: `{type}: 기능설명`
+```
+feat: 예정 경기 동기화 배치 구현
+fix: 인플레이 감지 스케줄러 NPE 수정
+```
+
+### 📝 Issue Title Convention
+> 형식: `{깃모지} {Type}: 기능설명`
+```
+✨ Feat: 예정 경기 배치 동기화
+🐛 Fix: 경기 상세 동기화 오류
+```
+
+### 🔃 Pull Request Title Convention
+> 형식: `{Type}: 기능 설명`
+```
+Feat: 예정 경기 동기화 배치 구현
+Fix: 인플레이 감지 스케줄러 NPE 수정
+```
+
+---
+
+## 🚀 Deploy
+
+> 운영 서버 배포 : `main` 브랜치
+> 개발 서버 배포 : `develop` 브랜치

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -31,17 +31,32 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+// QClass 생성 위치
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets{
+    main.java.srcDirs += [querydslDir]
+}
+
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueCacheService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueCacheService.java
@@ -20,7 +20,7 @@ public class LeagueCacheService {
 	private static final String CACHE_PREFIX = "league:";
 	private static final Duration CACHE_TTL = Duration.ofMinutes(30);
 	private final RedisTemplate<String, Object> redisTemplate;
-	private final LeagueRepository leaguerepository;
+	private final LeagueRepository leagueRepository;
 
 	/**
 	 * 리그 조회
@@ -39,7 +39,7 @@ public class LeagueCacheService {
 
 		// 2. DB 조회
 		log.debug("Cache MISS - League: {}", leagueId);
-		Optional<League> league = leaguerepository.findById(leagueId);
+		Optional<League> league = leagueRepository.findById(leagueId);
 
 		// 3. 캐시 저장
 		league.ifPresent(l -> {

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueCacheService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueCacheService.java
@@ -1,0 +1,82 @@
+package com.scorenow.scorenow_api.domain.league.service;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LeagueCacheService {
+
+	private static final String CACHE_PREFIX = "league:";
+	private static final Duration CACHE_TTL = Duration.ofMinutes(30);
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final LeagueRepository leaguerepository;
+
+	/**
+	 * 리그 조회
+	 * 1. Redis에서 먼저 조회
+	 * 2. 없으면 DB 조회 후 Redis에 저장
+	 */
+	public Optional<League> get(String leagueId){
+		String cacheKey = CACHE_PREFIX + leagueId;
+
+		// 1. 캐시 조회
+		League cachedLeague = (League) redisTemplate.opsForValue().get(cacheKey);
+		if(cachedLeague != null){
+			log.debug("CACHE HIT - League: {}", leagueId);
+			return Optional.of(cachedLeague);
+		}
+
+		// 2. DB 조회
+		log.debug("Cache MISS - League: {}", leagueId);
+		Optional<League> league = leaguerepository.findById(leagueId);
+
+		// 3. 캐시 저장
+		league.ifPresent(l -> {
+			redisTemplate.opsForValue().set(cacheKey, l, CACHE_TTL);
+			log.debug("Cache SET - League: {}", leagueId);
+		});
+
+		return league;
+	}
+
+	/**
+	 * 리그 캐시 삭제
+	 */
+	public void delete(String leagueId){
+		String cacheKey = CACHE_PREFIX + leagueId;
+		redisTemplate.delete(cacheKey);
+		log.info("Cache DELETE - League: {}", leagueId);
+	}
+
+	/**
+	 * 전체 리그 캐시 초기화
+	 */
+	public void invalidateAll(){
+		String pattern = CACHE_PREFIX + "*";
+		var keys = redisTemplate.keys(pattern);
+		if(keys != null && !keys.isEmpty()){
+			redisTemplate.delete(keys);
+			log.info("Cache INVALIDATE ALL - League count: {}", keys.size());
+		}
+	}
+
+	/**
+	 * 리그 캐시 강제 갱신
+	 * DB 조회 후 캐시 업데이트
+	 */
+	public Optional<League> refresh(String leagueId){
+		delete(leagueId);
+		return get(leagueId);
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAdminController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAdminController.java
@@ -4,7 +4,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -64,12 +63,4 @@ public class MatchAdminController {
 		return ApiResponse.success(null);
 	}
 
-	/**
-	 * 경기 삭제
-	 */
-	@DeleteMapping("/{matchId}")
-	public ApiResponse<Void> deleteMatch(@PathVariable String matchId){
-		matchAdminService.deleteMatch(matchId);
-		return ApiResponse.success(null);
-	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAdminController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAdminController.java
@@ -43,14 +43,6 @@ public class MatchAdminController {
 		return ApiResponse.success(result);
 	}
 
-	/**
-	 * 경기 상세 조회
-	 */
-	@GetMapping("/{matchId}")
-	public ApiResponse<MatchListResponse> getMatch(@PathVariable String matchId){
-		MatchListResponse result = matchAdminService.getMatch(matchId);
-		return ApiResponse.success(result);
-	}
 
 	/**
 	 * 경기 수동 등록

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAdminController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAdminController.java
@@ -1,0 +1,83 @@
+package com.scorenow.scorenow_api.domain.match.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.scorenow.scorenow_api.domain.match.dto.MatchSearchCondition;
+import com.scorenow.scorenow_api.domain.match.dto.request.MatchCreateRequest;
+import com.scorenow.scorenow_api.domain.match.dto.request.MatchUpdateRequest;
+import com.scorenow.scorenow_api.domain.match.dto.response.MatchListResponse;
+import com.scorenow.scorenow_api.domain.match.service.MatchAdminService;
+import com.scorenow.scorenow_api.global.dto.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/admin/matches")
+@RequiredArgsConstructor
+public class MatchAdminController {
+
+	private final MatchAdminService matchAdminService;
+
+	/**
+	 * 경기 리스트 조회
+	 */
+	@GetMapping
+	public ApiResponse<Page<MatchListResponse>> getMatches(
+		@ModelAttribute MatchSearchCondition condition,
+		@PageableDefault(size = 20, sort = "startAt", direction = Sort.Direction.ASC)Pageable pageable) {
+
+		Page<MatchListResponse> result = matchAdminService.getMatches(condition, pageable);
+		return ApiResponse.success(result);
+	}
+
+	/**
+	 * 경기 상세 조회
+	 */
+	@GetMapping("/{matchId}")
+	public ApiResponse<MatchListResponse> getMatch(@PathVariable String matchId){
+		MatchListResponse result = matchAdminService.getMatch(matchId);
+		return ApiResponse.success(result);
+	}
+
+	/**
+	 * 경기 수동 등록
+	 */
+	@PostMapping
+	public ApiResponse<MatchListResponse> createMatch(@Valid @RequestBody MatchCreateRequest request){
+		MatchListResponse result = matchAdminService.createMatch(request);
+		return ApiResponse.success(result);
+	}
+
+	/**
+	 * 경기 수정
+	 */
+	@PatchMapping("/{matchId}")
+	public ApiResponse<Void> updateMatch(
+		@PathVariable String matchId,
+		@Valid @RequestBody MatchUpdateRequest request){
+		matchAdminService.updateMatch(matchId, request);
+		return ApiResponse.success(null);
+	}
+
+	/**
+	 * 경기 삭제
+	 */
+	@DeleteMapping("/{matchId}")
+	public ApiResponse<Void> deleteMatch(@PathVariable String matchId){
+		matchAdminService.deleteMatch(matchId);
+		return ApiResponse.success(null);
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/MatchSearchCondition.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/MatchSearchCondition.java
@@ -1,0 +1,17 @@
+package com.scorenow.scorenow_api.domain.match.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MatchSearchCondition {
+	private String sportId;
+	private String leagueId;
+	private String leagueName; // 리그명 검색
+	private String status; // NOT_STARTED, INPLAY, ENDED 등
+	private Boolean isActive; // null = 전체, true = 사용중, false = 미사용
+	private String date;  // yyyyMMdd
+	private String sortBy; // sport, league, status, date (null이면 기본값: date)
+	private String sortDirection; // ASC, DESC (null이면 기본값: ASC)
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchCreateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchCreateRequest.java
@@ -13,9 +13,6 @@ import lombok.Setter;
 @Setter
 public class MatchCreateRequest {
 
-	@NotBlank(message = "경기 타입은 필수입니다.")
-	private String matchType; // A(자동), M(수동)
-
 	@NotBlank(message = "종목 ID는 필수입니다.")
 	private String sportId;
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchCreateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchCreateRequest.java
@@ -1,0 +1,31 @@
+package com.scorenow.scorenow_api.domain.match.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MatchCreateRequest {
+
+	@NotBlank(message = "종목 ID는 필수입니다.")
+	private String sportId;
+
+	@NotBlank(message = "리그 ID는 필수입니다.")
+	private String leagueId;
+
+	@NotBlank(message = "홈팀 ID는 필수입니다.")
+	private String homeId;
+
+	@NotBlank(message = "원정팀 ID는 필수입니다.")
+	private String awayId;
+
+	@NotNull(message = "경기 시작 시간은 필수입니다.")
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime startAt;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchCreateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchCreateRequest.java
@@ -13,6 +13,9 @@ import lombok.Setter;
 @Setter
 public class MatchCreateRequest {
 
+	@NotBlank(message = "경기 타입은 필수입니다.")
+	private String matchType; // A(자동), M(수동)
+
 	@NotBlank(message = "종목 ID는 필수입니다.")
 	private String sportId;
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchUpdateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.scorenow.scorenow_api.domain.match.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.Getter;
+
+@Getter
+public class MatchUpdateRequest {
+
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime startAt;
+
+	private String statusCode; // NOT_STARTED, INPLAY, ENDED
+
+	private Integer homeScore;
+
+	private Integer awayScore;
+
+	private Boolean isActive;
+}
+
+

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchUpdateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchUpdateRequest.java
@@ -5,12 +5,11 @@ import java.time.LocalDateTime;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class MatchUpdateRequest {
-
-	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-	private LocalDateTime startAt;
 
 	private String statusCode; // NOT_STARTED, INPLAY, ENDED
 
@@ -19,6 +18,7 @@ public class MatchUpdateRequest {
 	private Integer awayScore;
 
 	private Boolean isActive;
+
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime startAt;
 }
-
-

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchListResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchListResponse.java
@@ -1,0 +1,42 @@
+package com.scorenow.scorenow_api.domain.match.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MatchListResponse {
+	private String id;
+	private String sportId;
+	private String sportName;
+	private String leagueId;
+	private String leagueName;
+	private String matchType;
+	private LocalDateTime startAt;
+	private String statusCode;
+	private String statusName;
+	private String homeId;
+	private String homeName;
+	private String homeImageUrl;
+	private Integer homeScore;
+	private String awayId;
+	private String awayName;
+	private String awayImageUrl;
+	private Integer awayScore;
+	private boolean isManual;
+	private boolean isActive;
+
+	// 상세 조회용
+	private String betsApiEventId;
+	private String bet365Id;
+
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime createdAt;
+
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchListResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchListResponse.java
@@ -16,7 +16,6 @@ public class MatchListResponse {
 	private String leagueId;
 	private String leagueName;
 	private String matchType;
-	private LocalDateTime startAt;
 	private String statusCode;
 	private String statusName;
 	private String homeId;
@@ -30,13 +29,6 @@ public class MatchListResponse {
 	private boolean isManual;
 	private boolean isActive;
 
-	// 상세 조회용
-	private String betsApiEventId;
-	private String bet365Id;
-
 	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-	private LocalDateTime createdAt;
-
-	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-	private LocalDateTime updatedAt;
+	private LocalDateTime startAt;
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,8 +25,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "matches")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 public class Match extends BaseEntity {
 	@Id
@@ -116,5 +117,11 @@ public class Match extends BaseEntity {
 	public void updateIsActive(boolean isActive) {
 		this.isActive = isActive;
 	}
+
+	public boolean isDeletable() {
+		return this.isManual;
+	}
+
+
 }
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
@@ -1,6 +1,7 @@
 package com.scorenow.scorenow_api.domain.match.entity;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import com.scorenow.scorenow_api.global.entity.BaseEntity;
 
@@ -13,12 +14,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(name = "matches")
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -52,6 +51,47 @@ public class Match extends BaseEntity {
 
 	public static String generateMatchId(String sportId, String eventId) {
 		return "BETS" + sportId + eventId;
+	}
+
+	public static String generateManualId(String sportId) {
+		String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+		return String.format("MANUAL%s%s", sportId, uuid);
+	}
+
+	public void updateSportId(String sportId) {
+		this.sportId = sportId;
+	}
+
+	public void updateLeagueId(String leagueId) {
+		this.leagueId = leagueId;
+	}
+
+	public void updateHomeId(String homeId) {
+		this.homeId = homeId;
+	}
+
+	public void updateAwayId(String awayId) {
+		this.awayId = awayId;
+	}
+
+	public void updateStartAt(LocalDateTime startAt) {
+		this.startAt = startAt;
+	}
+
+	public void updateStatus(MatchStatus statusCode) {
+		this.statusCode = statusCode;
+	}
+
+	public void updateHomeScore(Integer homeScore) {
+		this.homeScore = homeScore;
+	}
+
+	public void updateAwayScore(Integer awayScore) {
+		this.awayScore = awayScore;
+	}
+
+	public void updateIsActive(boolean isActive) {
+		this.isActive = isActive;
 	}
 }
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
@@ -3,12 +3,18 @@ package com.scorenow.scorenow_api.domain.match.entity;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.sport.entity.Sport;
+import com.scorenow.scorenow_api.domain.team.entity.Team;
 import com.scorenow.scorenow_api.global.entity.BaseEntity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,6 +54,23 @@ public class Match extends BaseEntity {
 
 	private String betsApiEventId;
 	private String bet365Id;
+
+	// JPA 관계 추가 (Fetch join용)
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "leagueId", insertable = false, updatable = false)
+	private League league;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "sportId", insertable = false, updatable = false)
+	private Sport sport;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "homeId", insertable = false, updatable = false)
+	private Team homeTeam;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "awayId", insertable = false, updatable = false)
+	private Team awayTeam;
 
 	public static String generateMatchId(String sportId, String eventId) {
 		return "BETS" + sportId + eventId;

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
@@ -54,7 +54,7 @@ public class Match extends BaseEntity {
 	}
 
 	public static String generateManualId(String sportId) {
-		String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+		String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
 		return String.format("MANUAL%s%s", sportId, uuid);
 	}
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
@@ -118,10 +118,6 @@ public class Match extends BaseEntity {
 		this.isActive = isActive;
 	}
 
-	public boolean isDeletable() {
-		return this.isManual;
-	}
-
 
 }
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchType.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchType.java
@@ -1,0 +1,24 @@
+package com.scorenow.scorenow_api.domain.match.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MatchType {
+	A("A", "자동"),
+	M("M", "수동");
+
+	private final String code;
+	private final String description;
+
+	public static MatchType fromCode(String code){
+		if(code == null) return A;
+		for(MatchType type: values()){
+			if(type.code.equalsIgnoreCase(code)){
+				return type;
+			}
+		}
+		return A;
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchType.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchType.java
@@ -6,8 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MatchType {
-	A("A", "자동"),
-	M("M", "수동");
+	A("A", "일반");
 
 	private final String code;
 	private final String description;

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/mapper/MatchMapper.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/mapper/MatchMapper.java
@@ -46,7 +46,7 @@ public class MatchMapper {
 			.awayId(request.getAwayId())
 			.startAt(request.getStartAt())
 			.statusCode(MatchStatus.NOT_STARTED)
-			.matchType("M")
+			.matchType("A")
 			.isManual(true)
 			.isActive(false)
 			.build();

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/mapper/MatchMapper.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/mapper/MatchMapper.java
@@ -1,0 +1,70 @@
+package com.scorenow.scorenow_api.domain.match.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.match.dto.request.MatchCreateRequest;
+import com.scorenow.scorenow_api.domain.match.dto.response.MatchListResponse;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+import com.scorenow.scorenow_api.domain.sport.entity.Sport;
+import com.scorenow.scorenow_api.domain.team.entity.Team;
+
+@Component
+public class MatchMapper {
+
+	public MatchListResponse toResponse(Match match) {
+		return MatchListResponse.builder()
+			.id(match.getId())
+			.sportId(match.getSportId())
+			.sportName(getSportName(match.getSport()))
+			.leagueId(match.getLeagueId())
+			.leagueName(getLeagueName(match.getLeague()))
+			.matchType(match.getMatchType())
+			.startAt(match.getStartAt())
+			.statusCode(match.getStatusCode().name())
+			.statusName(match.getStatusCode().getDescription())
+			.homeId(match.getHomeId())
+			.homeName(getTeamName(match.getHomeTeam()))
+			.homeImageUrl(getTeamImageUrl(match.getHomeTeam()))
+			.homeScore(match.getHomeScore())
+			.awayId(match.getAwayId())
+			.awayName(getTeamName(match.getAwayTeam()))
+			.awayImageUrl(getTeamImageUrl(match.getAwayTeam()))
+			.awayScore(match.getAwayScore())
+			.isManual(match.isManual())
+			.isActive(match.isActive())
+			.build();
+	}
+
+	public Match toEntity(MatchCreateRequest request) {
+		return Match.builder()
+			.id(Match.generateManualId(request.getSportId()))
+			.sportId(request.getSportId())
+			.leagueId(request.getLeagueId())
+			.homeId(request.getHomeId())
+			.awayId(request.getAwayId())
+			.startAt(request.getStartAt())
+			.statusCode(MatchStatus.NOT_STARTED)
+			.matchType("M")
+			.isManual(true)
+			.isActive(false)
+			.build();
+	}
+
+	private String getSportName(Sport sport) {
+		return sport != null ? sport.getEName() : "";
+	}
+
+	private String getLeagueName(League league) {
+		return league != null ? league.getEName() : "";
+	}
+
+	private String getTeamName(Team team) {
+		return team != null ? team.getEName() : "";
+	}
+
+	private String getTeamImageUrl(Team team) {
+		return team != null ? team.getImageUrl() : null;
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/mapper/MatchMapper.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/mapper/MatchMapper.java
@@ -52,6 +52,13 @@ public class MatchMapper {
 			.build();
 	}
 
+	private String generateMatchId(String sportId, boolean isManual){
+		if(isManual){
+			return Match.generateManualId(sportId);
+		}
+		return Match.generateManualId(sportId);
+	}
+
 	private String getSportName(Sport sport) {
 		return sport != null ? sport.getEName() : "";
 	}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
@@ -10,7 +10,7 @@ import com.scorenow.scorenow_api.domain.match.dto.InplayMatchDetectionDto;
 import com.scorenow.scorenow_api.domain.match.entity.Match;
 import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
 
-public interface MatchRepository extends JpaRepository<Match, String> {
+public interface MatchRepository extends JpaRepository<Match, String>, MatchRepositoryCustom {
 	List<Match> findByStatusCode(MatchStatus statusCode);
 
 	@Query("""

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryCustom.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryCustom.java
@@ -1,5 +1,7 @@
 package com.scorenow.scorenow_api.domain.match.repository.jpa;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,4 +10,5 @@ import com.scorenow.scorenow_api.domain.match.entity.Match;
 
 public interface MatchRepositoryCustom {
 	Page<Match> searchMatches(MatchSearchCondition condition, Pageable pageable);
+	Optional<Match> findByIdWithRelations(String id);
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryCustom.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.scorenow.scorenow_api.domain.match.repository.jpa;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.scorenow.scorenow_api.domain.match.dto.MatchSearchCondition;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+
+public interface MatchRepositoryCustom {
+	Page<Match> searchMatches(MatchSearchCondition condition, Pageable pageable);
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryImpl.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryImpl.java
@@ -1,0 +1,132 @@
+package com.scorenow.scorenow_api.domain.match.repository.jpa;
+
+import static com.scorenow.scorenow_api.domain.match.entity.QMatch.*;
+import static com.scorenow.scorenow_api.domain.league.entity.QLeague.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.scorenow.scorenow_api.domain.match.dto.MatchSearchCondition;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MatchRepositoryImpl implements MatchRepositoryCustom{
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<Match> searchMatches(MatchSearchCondition condition, Pageable pageable){
+		List<Match> content = queryFactory
+			.selectFrom(match)
+			.leftJoin(league).on(match.leagueId.eq(league.id))
+			.where(
+				sportIdEq(condition.getSportId()),
+				leagueIdEq(condition.getLeagueId()),
+				leagueNameContains(condition.getLeagueName()),
+				statusEq(condition.getStatus()),
+				isActiveEq(condition.getIsActive()),
+				dateBetween(condition.getDate())
+			)
+			.orderBy(createOrderSpecifier(condition.getSortBy(), condition.getSortDirection()))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long total = queryFactory
+			.select(match.count())
+			.from(match)
+			.leftJoin(league).on(match.leagueId.eq(league.id))
+			.where(
+				sportIdEq(condition.getSportId()),
+				leagueIdEq(condition.getLeagueId()),
+				leagueNameContains(condition.getLeagueName()),
+				statusEq(condition.getStatus()),
+				isActiveEq(condition.getIsActive()),
+				dateBetween(condition.getDate())
+			)
+			.fetchOne();
+
+		return new PageImpl<>(content, pageable, total != null ? total: 0L);
+	}
+
+	private BooleanExpression sportIdEq(String sportId){
+		return sportId != null ? match.sportId.eq(sportId) : null;
+	}
+
+	private BooleanExpression leagueIdEq(String leagueId){
+		return leagueId != null ? match.leagueId.eq(leagueId) : null;
+	}
+
+	private BooleanExpression leagueNameContains(String leagueName){
+		if(!StringUtils.hasText(leagueName)) return null;
+		return league.kName.contains(leagueName)
+			.or(league.eName.contains(leagueName))
+			.or(league.sName.contains(leagueName));
+	}
+
+	private BooleanExpression statusEq(String status){
+		if(status == null || status.isBlank()) return null;
+		try{
+			return match.statusCode.eq(MatchStatus.valueOf(status));
+		}catch (Exception e){
+			return null;
+		}
+	}
+
+	private BooleanExpression isActiveEq(Boolean isActive){
+		return isActive != null ? match.isActive.eq(isActive): null;
+	}
+
+	private BooleanExpression dateBetween(String date){
+		if(date == null || date.isBlank()) return null;
+
+		try {
+			LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyyMMdd"));
+			LocalDateTime startOfDay = localDate.atStartOfDay();
+			LocalDateTime endOfDay = localDate.atTime(LocalTime.MAX);
+
+			return match.startAt.between(startOfDay, endOfDay);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	private OrderSpecifier<?> createOrderSpecifier(String sortBy, String sortDirection){
+		Order order = "DESC".equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
+
+		// sortBy가 null이면 기본값: 날짜 오름차순
+		if(sortBy == null || sortBy.isBlank()){
+			return new OrderSpecifier<>(Order.ASC, match.startAt);
+		}
+
+		switch(sortBy.toLowerCase()){
+			case "sport":
+				return new OrderSpecifier<>(order, match.sportId);
+			case "league":
+				return new OrderSpecifier<>(order, league.kName);
+			case "status":
+				return new OrderSpecifier<>(order, match.statusCode);
+			case "date":
+				return new OrderSpecifier<>(order, match.startAt);
+			default:
+				return new OrderSpecifier<>(Order.ASC, match.startAt);
+		}
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryImpl.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryImpl.java
@@ -3,13 +3,13 @@ package com.scorenow.scorenow_api.domain.match.repository.jpa;
 import static com.scorenow.scorenow_api.domain.league.entity.QLeague.*;
 import static com.scorenow.scorenow_api.domain.match.entity.QMatch.*;
 import static com.scorenow.scorenow_api.domain.sport.entity.QSport.*;
-import static com.scorenow.scorenow_api.domain.team.entity.QTeam.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -70,6 +70,23 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom{
 
 		return new PageImpl<>(content, pageable, total != null ? total: 0L);
 	}
+
+	@Override
+	public Optional<Match> findByIdWithRelations(String id){
+		Match result = queryFactory
+			.selectFrom(match)
+			.leftJoin(match.sport, sport).fetchJoin()
+			.leftJoin(match.league, league).fetchJoin()
+			.leftJoin(match.homeTeam).fetchJoin()
+			.leftJoin(match.awayTeam).fetchJoin()
+			.where(match.id.eq(id))
+			.fetchOne();
+
+		return Optional.ofNullable(result);
+	}
+
+
+	// === Private Helper Methods ===
 
 	private BooleanExpression sportIdEq(String sportId){
 		return sportId != null ? match.sportId.eq(sportId) : null;

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryImpl.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.scorenow.scorenow_api.domain.match.repository.jpa;
 
 import static com.scorenow.scorenow_api.domain.league.entity.QLeague.*;
 import static com.scorenow.scorenow_api.domain.match.entity.QMatch.*;
+import static com.scorenow.scorenow_api.domain.sport.entity.QSport.*;
+import static com.scorenow.scorenow_api.domain.team.entity.QTeam.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -35,7 +37,10 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom{
 	public Page<Match> searchMatches(MatchSearchCondition condition, Pageable pageable){
 		List<Match> content = queryFactory
 			.selectFrom(match)
-			.leftJoin(league).on(match.leagueId.eq(league.id))
+			.leftJoin(match.league, league).fetchJoin()
+			.leftJoin(match.sport, sport).fetchJoin()
+			.leftJoin(match.homeTeam).fetchJoin()
+			.leftJoin(match.awayTeam).fetchJoin()
 			.where(
 				sportIdEq(condition.getSportId()),
 				leagueIdEq(condition.getLeagueId()),

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryImpl.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.scorenow.scorenow_api.domain.match.repository.jpa;
 
-import static com.scorenow.scorenow_api.domain.match.entity.QMatch.*;
 import static com.scorenow.scorenow_api.domain.league.entity.QLeague.*;
+import static com.scorenow.scorenow_api.domain.match.entity.QMatch.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -84,7 +84,7 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom{
 	private BooleanExpression statusEq(String status){
 		if(status == null || status.isBlank()) return null;
 		try{
-			return match.statusCode.eq(MatchStatus.valueOf(status));
+			return match.statusCode.eq(MatchStatus.valueOf(status.toUpperCase()));
 		}catch (Exception e){
 			return null;
 		}
@@ -103,7 +103,7 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom{
 			LocalDateTime endOfDay = localDate.atTime(LocalTime.MAX);
 
 			return match.startAt.between(startOfDay, endOfDay);
-		} catch (Exception e) {
+		} catch (java.time.format.DateTimeParseException e) {
 			return null;
 		}
 	}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchSyncScheduler.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchSyncScheduler.java
@@ -1,0 +1,64 @@
+package com.scorenow.scorenow_api.domain.match.scheduler;
+
+import java.time.LocalDate;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.scorenow.scorenow_api.domain.match.service.MatchSyncService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MatchSyncScheduler {
+
+	// 지원 종목 ID(축구 , 확장 가능)
+	private static final String FOOTBALL = "1";
+	private final MatchSyncService matchSyncService;
+
+	/**
+	 * 예정 경기 동기화(Upcoming)
+	 * 일주일치 데이터 가져오기
+	 */
+	@Scheduled(cron = "0 0 0,6,12,18 * * *")
+	public void syncUpcomingMatches(){
+		log.info("=== [UPCOMING] 예정 경기 동기화 ===");
+
+		int totalCount = 0;
+		LocalDate today = LocalDate.now();
+
+		try{
+			// 오늘 경기
+			int todayCount = matchSyncService.syncUpcomingMatches(FOOTBALL, null);
+
+			// 내일 경기
+			String tomorrow = java.time.LocalDate.now().plusDays(1)
+				.format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
+			int tomorrowCount = matchSyncService.syncUpcomingMatches(FOOTBALL, tomorrow);
+
+			log.info("[UPCOMING] 동기화 완료 - 오늘 {}건, 내일: {}건", todayCount, tomorrowCount);
+		} catch (Exception e) {
+			log.error("[UPCOMING] 동기화 실패", e);
+		}
+	}
+
+	/**
+	 * 종료 경기 동기화(Ended)
+	 * - 매 10분마다 동기화
+	 * - 최종 스코어 및 상태 확정
+	 */
+	@Scheduled(fixedDelay = 600000)
+	public void syncEndedMatches(){
+		log.info("=== [ENDED] 종료 경기 동기화 시작 ===");
+		try{
+			int count = matchSyncService.syncEndedMatches(FOOTBALL, null);
+			log.info("[ENDED] 동기화 완료 - {}건", count);
+		} catch (Exception e) {
+			log.error("[ENDED] 동기화 실패", e);
+		}
+	}
+
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
@@ -1,0 +1,253 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueRepository;
+import com.scorenow.scorenow_api.domain.match.dto.MatchSearchCondition;
+import com.scorenow.scorenow_api.domain.match.dto.request.MatchCreateRequest;
+import com.scorenow.scorenow_api.domain.match.dto.request.MatchUpdateRequest;
+import com.scorenow.scorenow_api.domain.match.dto.response.MatchListResponse;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import com.scorenow.scorenow_api.domain.sport.entity.Sport;
+import com.scorenow.scorenow_api.domain.sport.repository.SportRepository;
+import com.scorenow.scorenow_api.domain.team.entity.Team;
+import com.scorenow.scorenow_api.domain.team.repository.TeamRepository;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MatchAdminService {
+
+	private final MatchRepository matchRepository;
+	private final LeagueRepository leagueRepository;
+	private final TeamRepository teamRepository;
+	private final SportRepository sportRepository;
+
+	/**
+	 * 경기 리스트 조회
+	 */
+	public Page<MatchListResponse> getMatches(MatchSearchCondition condition, Pageable pageable) {
+		Page<Match> matches = matchRepository.searchMatches(condition, pageable);
+		List<Match> matchList = matches.getContent();
+
+		// ID 일괄 수집
+		Set<String> leagueIds = matchList.stream().map(Match::getLeagueId).filter(id -> id != null).collect(Collectors.toSet());
+		Set<String> teamIds = matchList.stream()
+			.flatMap(m -> Stream.of(m.getHomeId(), m.getAwayId()))
+			.filter(id -> id != null)
+			.collect(Collectors.toSet());
+		Set<String> sportIds = matchList.stream().map(Match::getSportId).filter(id -> id != null).collect(Collectors.toSet());
+
+		// 일괄 조회
+		Map<String, League> leagueMap = leagueRepository.findAllById(leagueIds).stream()
+			.collect(Collectors.toMap(League::getId, Function.identity()));
+		Map<String, Team> teamMap = teamRepository.findAllById(teamIds).stream()
+			.collect(Collectors.toMap(Team::getId, Function.identity()));
+		Map<String, Sport> sportMap = sportRepository.findAllById(sportIds).stream()
+			.collect(Collectors.toMap(Sport::getId, Function.identity()));
+
+		List<MatchListResponse> content = matchList.stream()
+			.map(match -> toListResponse(match, false, leagueMap, teamMap, sportMap))
+			.toList();
+
+		return new PageImpl<>(content, pageable, matches.getTotalElements());
+	}
+
+	/**
+	 * 경기 상세 조회
+	 */
+	public MatchListResponse getMatch(String matchId) {
+		Match match = matchRepository.findById(matchId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.MATCH_NOT_FOUND));
+
+		League leagueEntity = match.getLeagueId() != null ? leagueRepository.findById(match.getLeagueId()).orElse(null) : null;
+		Team homeTeam = match.getHomeId() != null ? teamRepository.findById(match.getHomeId()).orElse(null) : null;
+		Team awayTeam = match.getAwayId() != null ? teamRepository.findById(match.getAwayId()).orElse(null) : null;
+		Sport sportEntity = match.getSportId() != null ? sportRepository.findById(match.getSportId()).orElse(null) : null;
+
+		return toListResponse(match, true, leagueEntity, homeTeam, awayTeam, sportEntity);
+	}
+
+	/**
+	 * 경기 수동 등록
+	 */
+	@Transactional
+	public MatchListResponse createMatch(MatchCreateRequest request) {
+		// 리그 존재 확인
+		if (!leagueRepository.existsById(request.getLeagueId())) {
+			throw new BusinessException(ErrorCode.LEAGUE_NOT_FOUND);
+		}
+
+		// 홈팀 존재 확인
+		if (!teamRepository.existsById(request.getHomeId())) {
+			throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "홈팀을 찾을 수 없습니다.");
+		}
+
+		// 원정팀 존재 확인
+		if (!teamRepository.existsById(request.getAwayId())) {
+			throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "원정팀을 찾을 수 없습니다.");
+		}
+
+		// 수동 경기 생성
+		Match match = Match.builder()
+			.id(Match.generateManualId(request.getSportId()))
+			.sportId(request.getSportId())
+			.leagueId(request.getLeagueId())
+			.homeId(request.getHomeId())
+			.awayId(request.getAwayId())
+			.startAt(request.getStartAt())
+			.statusCode(MatchStatus.NOT_STARTED)
+			.matchType("M")
+			.isManual(true)
+			.isActive(false)
+			.build();
+
+		matchRepository.save(match);
+		log.info("수동 경기 등록 완료 - matchId: {}", match.getId());
+
+		League leagueEntity = leagueRepository.findById(request.getLeagueId()).orElse(null);
+		Team homeTeam = teamRepository.findById(request.getHomeId()).orElse(null);
+		Team awayTeam = teamRepository.findById(request.getAwayId()).orElse(null);
+		Sport sportEntity = request.getSportId() != null ? sportRepository.findById(request.getSportId()).orElse(null) : null;
+
+		return toListResponse(match, true, leagueEntity, homeTeam, awayTeam, sportEntity);
+	}
+
+	/**
+	 * 경기 수정
+	 */
+	@Transactional
+	public void updateMatch(String matchId, MatchUpdateRequest request) {
+		Match match = findMatchById(matchId);
+
+		// 시작 시간 수정
+		if (request.getStartAt() != null) {
+			match.updateStartAt(request.getStartAt());
+		}
+
+		// 경기 상태 수정
+		if (request.getStatusCode() != null) {
+			try {
+				MatchStatus status = MatchStatus.valueOf(request.getStatusCode());
+				match.updateStatus(status);
+			} catch (IllegalArgumentException e) {
+				throw new BusinessException(ErrorCode.MATCH_INVALID_STATUS);
+			}
+		}
+
+		// 점수 수정
+		if (request.getHomeScore() != null) {
+			match.updateHomeScore(request.getHomeScore());
+		}
+		if (request.getAwayScore() != null) {
+			match.updateAwayScore(request.getAwayScore());
+		}
+
+		// 사용 여부 수정
+		if (request.getIsActive() != null) {
+			match.updateIsActive(request.getIsActive());
+		}
+
+		matchRepository.save(match);
+		log.info("경기 수정 완료 - matchId: {}", matchId);
+	}
+
+	/**
+	 * 경기 삭제
+	 */
+	@Transactional
+	public void deleteMatch(String matchId) {
+		Match match = findMatchById(matchId);
+
+		// 수동 경기만 삭제 가능
+		if (!match.isManual()) {
+			throw new BusinessException(ErrorCode.MATCH_CANNOT_DELETE, "자동 경기는 삭제할 수 없습니다.");
+		}
+
+		matchRepository.delete(match);
+		log.info("경기 삭제 완료 - matchId: {}", matchId);
+	}
+
+	/**
+	 * 경기 조회(공통)
+	 */
+	private Match findMatchById(String matchId) {
+		return matchRepository.findById(matchId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.MATCH_NOT_FOUND));
+	}
+
+	/**
+	 * Match -> MatchListResponse 변환 (리스트 조회용, 일괄 조회된 Map 사용)
+	 */
+	private MatchListResponse toListResponse(Match match, boolean includeDetail,
+		Map<String, League> leagueMap, Map<String, Team> teamMap, Map<String, Sport> sportMap) {
+
+		League leagueEntity = match.getLeagueId() != null ? leagueMap.get(match.getLeagueId()) : null;
+		Team homeTeam = match.getHomeId() != null ? teamMap.get(match.getHomeId()) : null;
+		Team awayTeam = match.getAwayId() != null ? teamMap.get(match.getAwayId()) : null;
+		Sport sportEntity = match.getSportId() != null ? sportMap.get(match.getSportId()) : null;
+
+		return toListResponse(match, includeDetail, leagueEntity, homeTeam, awayTeam, sportEntity);
+	}
+
+	/**
+	 * Match -> MatchListResponse 변환 (상세 조회용)
+	 */
+	private MatchListResponse toListResponse(Match match, boolean includeDetail,
+		League leagueEntity, Team homeTeam, Team awayTeam, Sport sportEntity) {
+
+		String leagueName = leagueEntity != null ? leagueEntity.getEName() : "";
+		String sportName = sportEntity != null ? sportEntity.getKName() : "";
+
+		MatchListResponse.MatchListResponseBuilder builder = MatchListResponse.builder()
+			.id(match.getId())
+			.sportId(match.getSportId())
+			.sportName(sportName)
+			.leagueId(match.getLeagueId())
+			.leagueName(leagueName)
+			.matchType(match.getMatchType())
+			.startAt(match.getStartAt())
+			.statusCode(match.getStatusCode().name())
+			.statusName(match.getStatusCode().getDescription())
+			.homeId(match.getHomeId())
+			.homeName(homeTeam != null ? homeTeam.getEName() : "")
+			.homeImageUrl(homeTeam != null ? homeTeam.getImageUrl() : null)
+			.homeScore(match.getHomeScore())
+			.awayId(match.getAwayId())
+			.awayName(awayTeam != null ? awayTeam.getEName() : "")
+			.awayImageUrl(awayTeam != null ? awayTeam.getImageUrl() : null)
+			.awayScore(match.getAwayScore())
+			.isManual(match.isManual())
+			.isActive(match.isActive());
+
+		if (includeDetail) {
+			builder
+				.betsApiEventId(match.getBetsApiEventId())
+				.bet365Id(match.getBet365Id())
+				.createdAt(match.getCreatedAt())
+				.updatedAt(match.getUpdatedAt());
+		}
+
+		return builder.build();
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
@@ -2,6 +2,7 @@ package com.scorenow.scorenow_api.domain.match.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -51,12 +52,18 @@ public class MatchAdminService {
 		List<Match> matchList = matches.getContent();
 
 		// ID 일괄 수집
-		Set<String> leagueIds = matchList.stream().map(Match::getLeagueId).filter(id -> id != null).collect(Collectors.toSet());
+		Set<String> leagueIds = matchList.stream()
+			.map(Match::getLeagueId)
+			.filter(Objects::nonNull)
+			.collect(Collectors.toSet());
 		Set<String> teamIds = matchList.stream()
 			.flatMap(m -> Stream.of(m.getHomeId(), m.getAwayId()))
-			.filter(id -> id != null)
+			.filter(Objects::nonNull)
 			.collect(Collectors.toSet());
-		Set<String> sportIds = matchList.stream().map(Match::getSportId).filter(id -> id != null).collect(Collectors.toSet());
+		Set<String> sportIds = matchList.stream()
+			.map(Match::getSportId)
+			.filter(Objects::nonNull)
+			.collect(Collectors.toSet());
 
 		// 일괄 조회
 		Map<String, League> leagueMap = leagueRepository.findAllById(leagueIds).stream()
@@ -67,45 +74,24 @@ public class MatchAdminService {
 			.collect(Collectors.toMap(Sport::getId, Function.identity()));
 
 		List<MatchListResponse> content = matchList.stream()
-			.map(match -> toListResponse(match, false, leagueMap, teamMap, sportMap))
+			.map(match -> toListResponse(match, leagueMap, teamMap, sportMap))
 			.toList();
 
 		return new PageImpl<>(content, pageable, matches.getTotalElements());
 	}
 
-	/**
-	 * 경기 상세 조회
-	 */
-	public MatchListResponse getMatch(String matchId) {
-		Match match = matchRepository.findById(matchId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.MATCH_NOT_FOUND));
-
-		League leagueEntity = match.getLeagueId() != null ? leagueRepository.findById(match.getLeagueId()).orElse(null) : null;
-		Team homeTeam = match.getHomeId() != null ? teamRepository.findById(match.getHomeId()).orElse(null) : null;
-		Team awayTeam = match.getAwayId() != null ? teamRepository.findById(match.getAwayId()).orElse(null) : null;
-		Sport sportEntity = match.getSportId() != null ? sportRepository.findById(match.getSportId()).orElse(null) : null;
-
-		return toListResponse(match, true, leagueEntity, homeTeam, awayTeam, sportEntity);
-	}
 
 	/**
 	 * 경기 수동 등록
 	 */
 	@Transactional
 	public MatchListResponse createMatch(MatchCreateRequest request) {
-		// 리그 존재 확인
-		if (!leagueRepository.existsById(request.getLeagueId())) {
-			throw new BusinessException(ErrorCode.LEAGUE_NOT_FOUND);
-		}
-
-		// 홈팀 존재 확인
-		if (!teamRepository.existsById(request.getHomeId())) {
-			throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "홈팀을 찾을 수 없습니다.");
-		}
-
-		// 원정팀 존재 확인
-		if (!teamRepository.existsById(request.getAwayId())) {
-			throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "원정팀을 찾을 수 없습니다.");
+		// 연관 엔티티 존재 확인
+		fetchLeague(request.getLeagueId(), "리그 정보를 찾을 수 없습니다.");
+		fetchTeam(request.getHomeId(), "홈팀 정보를 찾을 수 없습니다.");
+		fetchTeam(request.getAwayId(), "원정팀 정보를 찾을 수 없습니다.");
+		if (request.getSportId() != null) {
+			fetchSport(request.getSportId(), "스포츠 정보를 찾을 수 없습니다.");
 		}
 
 		// 수동 경기 생성
@@ -125,12 +111,8 @@ public class MatchAdminService {
 		matchRepository.save(match);
 		log.info("수동 경기 등록 완료 - matchId: {}", match.getId());
 
-		League leagueEntity = leagueRepository.findById(request.getLeagueId()).orElse(null);
-		Team homeTeam = teamRepository.findById(request.getHomeId()).orElse(null);
-		Team awayTeam = teamRepository.findById(request.getAwayId()).orElse(null);
-		Sport sportEntity = request.getSportId() != null ? sportRepository.findById(request.getSportId()).orElse(null) : null;
-
-		return toListResponse(match, true, leagueEntity, homeTeam, awayTeam, sportEntity);
+		// 기본 정보만 반환
+		return toBasicResponse(match);
 	}
 
 	/**
@@ -188,8 +170,10 @@ public class MatchAdminService {
 		log.info("경기 삭제 완료 - matchId: {}", matchId);
 	}
 
+	// ======================== 헬퍼 메서드 ========================
+
 	/**
-	 * 경기 조회(공통)
+	 * 경기 조회 (공통)
 	 */
 	private Match findMatchById(String matchId) {
 		return matchRepository.findById(matchId)
@@ -197,9 +181,35 @@ public class MatchAdminService {
 	}
 
 	/**
+	 * 리그 조회 (존재하지 않으면 예외 발생)
+	 */
+	private void fetchLeague(String leagueId, String errorMessage) {
+		leagueRepository.findById(leagueId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.LEAGUE_NOT_FOUND, errorMessage));
+	}
+
+	/**
+	 * 팀 조회 (존재하지 않으면 예외 발생)
+	 */
+	private void fetchTeam(String teamId, String errorMessage) {
+		teamRepository.findById(teamId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND, errorMessage));
+	}
+
+	/**
+	 * 스포츠 조회 (존재하지 않으면 예외 발생)
+	 */
+	private void fetchSport(String sportId, String errorMessage) {
+		sportRepository.findById(sportId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.SPORT_NOT_FOUND, errorMessage));
+	}
+
+	// ======================== 응답 변환 메서드 ========================
+
+	/**
 	 * Match -> MatchListResponse 변환 (리스트 조회용, 일괄 조회된 Map 사용)
 	 */
-	private MatchListResponse toListResponse(Match match, boolean includeDetail,
+	private MatchListResponse toListResponse(Match match,
 		Map<String, League> leagueMap, Map<String, Team> teamMap, Map<String, Sport> sportMap) {
 
 		League leagueEntity = match.getLeagueId() != null ? leagueMap.get(match.getLeagueId()) : null;
@@ -207,19 +217,26 @@ public class MatchAdminService {
 		Team awayTeam = match.getAwayId() != null ? teamMap.get(match.getAwayId()) : null;
 		Sport sportEntity = match.getSportId() != null ? sportMap.get(match.getSportId()) : null;
 
-		return toListResponse(match, includeDetail, leagueEntity, homeTeam, awayTeam, sportEntity);
+		return buildMatchResponse(match, leagueEntity, homeTeam, awayTeam, sportEntity);
 	}
 
 	/**
-	 * Match -> MatchListResponse 변환 (상세 조회용)
+	 * Match -> MatchListResponse 변환 (기본 정보만 반환)
 	 */
-	private MatchListResponse toListResponse(Match match, boolean includeDetail,
+	private MatchListResponse toBasicResponse(Match match) {
+		return buildMatchResponse(match, null, null, null, null);
+	}
+
+	/**
+	 * MatchListResponse 생성
+	 */
+	private MatchListResponse buildMatchResponse(Match match,
 		League leagueEntity, Team homeTeam, Team awayTeam, Sport sportEntity) {
 
 		String leagueName = leagueEntity != null ? leagueEntity.getEName() : "";
-		String sportName = sportEntity != null ? sportEntity.getKName() : "";
+		String sportName = sportEntity != null ? sportEntity.getEName() : "";
 
-		MatchListResponse.MatchListResponseBuilder builder = MatchListResponse.builder()
+		return MatchListResponse.builder()
 			.id(match.getId())
 			.sportId(match.getSportId())
 			.sportName(sportName)
@@ -238,16 +255,9 @@ public class MatchAdminService {
 			.awayImageUrl(awayTeam != null ? awayTeam.getImageUrl() : null)
 			.awayScore(match.getAwayScore())
 			.isManual(match.isManual())
-			.isActive(match.isActive());
-
-		if (includeDetail) {
-			builder
-				.betsApiEventId(match.getBetsApiEventId())
-				.bet365Id(match.getBet365Id())
-				.createdAt(match.getCreatedAt())
-				.updatedAt(match.getUpdatedAt());
-		}
-
-		return builder.build();
+			.isActive(match.isActive())
+			.build();
 	}
+
+
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
@@ -12,6 +12,7 @@ import com.scorenow.scorenow_api.domain.match.dto.request.MatchUpdateRequest;
 import com.scorenow.scorenow_api.domain.match.dto.response.MatchListResponse;
 import com.scorenow.scorenow_api.domain.match.entity.Match;
 import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+import com.scorenow.scorenow_api.domain.match.entity.MatchType;
 import com.scorenow.scorenow_api.domain.match.mapper.MatchMapper;
 import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
 import com.scorenow.scorenow_api.domain.sport.repository.SportRepository;
@@ -87,6 +88,11 @@ public class MatchAdminService {
 	// === Validation Methods ===
 
 	private void validateMatchCreateRequest(MatchCreateRequest request) {
+		try{
+			MatchType.fromCode(request.getMatchType());
+		} catch (Exception e) {
+			throw new BusinessException(ErrorCode.MATCH_INVALID_TYPE);
+		}
 		if (!leagueRepository.existsById(request.getLeagueId())) {
 			throw new BusinessException(ErrorCode.LEAGUE_NOT_FOUND);
 		}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
@@ -1,12 +1,6 @@
 package com.scorenow.scorenow_api.domain.match.service;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -49,32 +43,10 @@ public class MatchAdminService {
 	 */
 	public Page<MatchListResponse> getMatches(MatchSearchCondition condition, Pageable pageable) {
 		Page<Match> matches = matchRepository.searchMatches(condition, pageable);
-		List<Match> matchList = matches.getContent();
 
-		// ID 일괄 수집
-		Set<String> leagueIds = matchList.stream()
-			.map(Match::getLeagueId)
-			.filter(Objects::nonNull)
-			.collect(Collectors.toSet());
-		Set<String> teamIds = matchList.stream()
-			.flatMap(m -> Stream.of(m.getHomeId(), m.getAwayId()))
-			.filter(Objects::nonNull)
-			.collect(Collectors.toSet());
-		Set<String> sportIds = matchList.stream()
-			.map(Match::getSportId)
-			.filter(Objects::nonNull)
-			.collect(Collectors.toSet());
-
-		// 일괄 조회
-		Map<String, League> leagueMap = leagueRepository.findAllById(leagueIds).stream()
-			.collect(Collectors.toMap(League::getId, Function.identity()));
-		Map<String, Team> teamMap = teamRepository.findAllById(teamIds).stream()
-			.collect(Collectors.toMap(Team::getId, Function.identity()));
-		Map<String, Sport> sportMap = sportRepository.findAllById(sportIds).stream()
-			.collect(Collectors.toMap(Sport::getId, Function.identity()));
-
-		List<MatchListResponse> content = matchList.stream()
-			.map(match -> toListResponse(match, leagueMap, teamMap, sportMap))
+		// Fetch 조인 적용
+		List<MatchListResponse> content = matches.getContent().stream()
+			.map(this::toListResponseWithFetch)
 			.toList();
 
 		return new PageImpl<>(content, pageable, matches.getTotalElements());
@@ -207,17 +179,31 @@ public class MatchAdminService {
 	// ======================== 응답 변환 메서드 ========================
 
 	/**
-	 * Match -> MatchListResponse 변환 (리스트 조회용, 일괄 조회된 Map 사용)
+	 * Match -> MatchListResponse 변환
 	 */
-	private MatchListResponse toListResponse(Match match,
-		Map<String, League> leagueMap, Map<String, Team> teamMap, Map<String, Sport> sportMap) {
+	private MatchListResponse toListResponseWithFetch(Match match) {
 
-		League leagueEntity = match.getLeagueId() != null ? leagueMap.get(match.getLeagueId()) : null;
-		Team homeTeam = match.getHomeId() != null ? teamMap.get(match.getHomeId()) : null;
-		Team awayTeam = match.getAwayId() != null ? teamMap.get(match.getAwayId()) : null;
-		Sport sportEntity = match.getSportId() != null ? sportMap.get(match.getSportId()) : null;
-
-		return buildMatchResponse(match, leagueEntity, homeTeam, awayTeam, sportEntity);
+		return MatchListResponse.builder()
+			.id(match.getId())
+			.sportId(match.getSportId())
+			.sportName(match.getSport() != null ? match.getSport().getEName() : "")
+			.leagueId(match.getLeagueId())
+			.leagueName(match.getLeague() != null ? match.getLeague().getEName() : "")
+			.matchType(match.getMatchType())
+			.startAt(match.getStartAt())
+			.statusCode(match.getStatusCode().name())
+			.statusName(match.getStatusCode().getDescription())
+			.homeId(match.getHomeId())
+			.homeName(match.getHomeTeam() != null ? match.getHomeTeam().getEName() : "")
+			.homeImageUrl(match.getHomeTeam() != null ? match.getHomeTeam().getImageUrl() : null)
+			.homeScore(match.getHomeScore())
+			.awayId(match.getAwayId())
+			.awayName(match.getAwayTeam() != null ? match.getAwayTeam().getEName() : "")
+			.awayImageUrl(match.getAwayTeam() != null ? match.getAwayTeam().getImageUrl() : null)
+			.awayScore(match.getAwayScore())
+			.isManual(match.isManual())
+			.isActive(match.isActive())
+			.build();
 	}
 
 	/**

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
@@ -12,7 +12,6 @@ import com.scorenow.scorenow_api.domain.match.dto.request.MatchUpdateRequest;
 import com.scorenow.scorenow_api.domain.match.dto.response.MatchListResponse;
 import com.scorenow.scorenow_api.domain.match.entity.Match;
 import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
-import com.scorenow.scorenow_api.domain.match.entity.MatchType;
 import com.scorenow.scorenow_api.domain.match.mapper.MatchMapper;
 import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
 import com.scorenow.scorenow_api.domain.sport.repository.SportRepository;
@@ -72,27 +71,9 @@ public class MatchAdminService {
 		log.info("경기 수정 완료 - matchId: {}", matchId);
 	}
 
-	/**
-	 * 경기 삭제
-	 */
-	@Transactional
-	public void deleteMatch(String matchId) {
-		Match match = findMatchById(matchId);
-
-		validateDeletable(match);
-
-		matchRepository.delete(match);
-		log.info("경기 삭제 완료 - matchId: {}", matchId);
-	}
-
 	// === Validation Methods ===
 
 	private void validateMatchCreateRequest(MatchCreateRequest request) {
-		try{
-			MatchType.fromCode(request.getMatchType());
-		} catch (Exception e) {
-			throw new BusinessException(ErrorCode.MATCH_INVALID_TYPE);
-		}
 		if (!leagueRepository.existsById(request.getLeagueId())) {
 			throw new BusinessException(ErrorCode.LEAGUE_NOT_FOUND);
 		}
@@ -104,12 +85,6 @@ public class MatchAdminService {
 		}
 		if (request.getSportId() != null && !sportRepository.existsById(request.getSportId())) {
 			throw new BusinessException(ErrorCode.SPORT_NOT_FOUND);
-		}
-	}
-
-	private void validateDeletable(Match match) {
-		if (!match.isDeletable()) {
-			throw new BusinessException(ErrorCode.MATCH_CANNOT_DELETE, "자동 경기는 삭제할 수 없습니다.");
 		}
 	}
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
@@ -1,14 +1,10 @@
 package com.scorenow.scorenow_api.domain.match.service;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.scorenow.scorenow_api.domain.league.entity.League;
 import com.scorenow.scorenow_api.domain.league.repository.LeagueRepository;
 import com.scorenow.scorenow_api.domain.match.dto.MatchSearchCondition;
 import com.scorenow.scorenow_api.domain.match.dto.request.MatchCreateRequest;
@@ -16,10 +12,9 @@ import com.scorenow.scorenow_api.domain.match.dto.request.MatchUpdateRequest;
 import com.scorenow.scorenow_api.domain.match.dto.response.MatchListResponse;
 import com.scorenow.scorenow_api.domain.match.entity.Match;
 import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+import com.scorenow.scorenow_api.domain.match.mapper.MatchMapper;
 import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
-import com.scorenow.scorenow_api.domain.sport.entity.Sport;
 import com.scorenow.scorenow_api.domain.sport.repository.SportRepository;
-import com.scorenow.scorenow_api.domain.team.entity.Team;
 import com.scorenow.scorenow_api.domain.team.repository.TeamRepository;
 import com.scorenow.scorenow_api.global.exception.BusinessException;
 import com.scorenow.scorenow_api.global.exception.ErrorCode;
@@ -37,54 +32,31 @@ public class MatchAdminService {
 	private final LeagueRepository leagueRepository;
 	private final TeamRepository teamRepository;
 	private final SportRepository sportRepository;
+	private final MatchMapper matchMapper;
 
 	/**
 	 * 경기 리스트 조회
 	 */
 	public Page<MatchListResponse> getMatches(MatchSearchCondition condition, Pageable pageable) {
-		Page<Match> matches = matchRepository.searchMatches(condition, pageable);
-
-		// Fetch 조인 적용
-		List<MatchListResponse> content = matches.getContent().stream()
-			.map(this::toListResponseWithFetch)
-			.toList();
-
-		return new PageImpl<>(content, pageable, matches.getTotalElements());
+		return matchRepository.searchMatches(condition, pageable)
+			.map(matchMapper::toResponse);
 	}
-
 
 	/**
 	 * 경기 수동 등록
 	 */
 	@Transactional
 	public MatchListResponse createMatch(MatchCreateRequest request) {
-		// 연관 엔티티 존재 확인
-		fetchLeague(request.getLeagueId(), "리그 정보를 찾을 수 없습니다.");
-		fetchTeam(request.getHomeId(), "홈팀 정보를 찾을 수 없습니다.");
-		fetchTeam(request.getAwayId(), "원정팀 정보를 찾을 수 없습니다.");
-		if (request.getSportId() != null) {
-			fetchSport(request.getSportId(), "스포츠 정보를 찾을 수 없습니다.");
-		}
+		validateMatchCreateRequest(request);
 
-		// 수동 경기 생성
-		Match match = Match.builder()
-			.id(Match.generateManualId(request.getSportId()))
-			.sportId(request.getSportId())
-			.leagueId(request.getLeagueId())
-			.homeId(request.getHomeId())
-			.awayId(request.getAwayId())
-			.startAt(request.getStartAt())
-			.statusCode(MatchStatus.NOT_STARTED)
-			.matchType("M")
-			.isManual(true)
-			.isActive(false)
-			.build();
-
+		Match match = matchMapper.toEntity(request);
 		matchRepository.save(match);
+
 		log.info("수동 경기 등록 완료 - matchId: {}", match.getId());
 
-		// 기본 정보만 반환
-		return toBasicResponse(match);
+		return matchRepository.findByIdWithRelations(match.getId())
+			.map(matchMapper::toResponse)
+			.orElseGet(() -> matchMapper.toResponse(match));
 	}
 
 	/**
@@ -94,35 +66,8 @@ public class MatchAdminService {
 	public void updateMatch(String matchId, MatchUpdateRequest request) {
 		Match match = findMatchById(matchId);
 
-		// 시작 시간 수정
-		if (request.getStartAt() != null) {
-			match.updateStartAt(request.getStartAt());
-		}
+		applyUpdates(match, request);
 
-		// 경기 상태 수정
-		if (request.getStatusCode() != null) {
-			try {
-				MatchStatus status = MatchStatus.valueOf(request.getStatusCode());
-				match.updateStatus(status);
-			} catch (IllegalArgumentException e) {
-				throw new BusinessException(ErrorCode.MATCH_INVALID_STATUS);
-			}
-		}
-
-		// 점수 수정
-		if (request.getHomeScore() != null) {
-			match.updateHomeScore(request.getHomeScore());
-		}
-		if (request.getAwayScore() != null) {
-			match.updateAwayScore(request.getAwayScore());
-		}
-
-		// 사용 여부 수정
-		if (request.getIsActive() != null) {
-			match.updateIsActive(request.getIsActive());
-		}
-
-		matchRepository.save(match);
 		log.info("경기 수정 완료 - matchId: {}", matchId);
 	}
 
@@ -133,117 +78,64 @@ public class MatchAdminService {
 	public void deleteMatch(String matchId) {
 		Match match = findMatchById(matchId);
 
-		// 수동 경기만 삭제 가능
-		if (!match.isManual()) {
-			throw new BusinessException(ErrorCode.MATCH_CANNOT_DELETE, "자동 경기는 삭제할 수 없습니다.");
-		}
+		validateDeletable(match);
 
 		matchRepository.delete(match);
 		log.info("경기 삭제 완료 - matchId: {}", matchId);
 	}
 
-	// ======================== 헬퍼 메서드 ========================
+	// === Validation Methods ===
 
-	/**
-	 * 경기 조회 (공통)
-	 */
+	private void validateMatchCreateRequest(MatchCreateRequest request) {
+		if (!leagueRepository.existsById(request.getLeagueId())) {
+			throw new BusinessException(ErrorCode.LEAGUE_NOT_FOUND);
+		}
+		if (!teamRepository.existsById(request.getHomeId())) {
+			throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "홈팀을 찾을 수 없습니다.");
+		}
+		if (!teamRepository.existsById(request.getAwayId())) {
+			throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "원정팀을 찾을 수 없습니다.");
+		}
+		if (request.getSportId() != null && !sportRepository.existsById(request.getSportId())) {
+			throw new BusinessException(ErrorCode.SPORT_NOT_FOUND);
+		}
+	}
+
+	private void validateDeletable(Match match) {
+		if (!match.isDeletable()) {
+			throw new BusinessException(ErrorCode.MATCH_CANNOT_DELETE, "자동 경기는 삭제할 수 없습니다.");
+		}
+	}
+
+	// === Helper Methods ===
+
 	private Match findMatchById(String matchId) {
 		return matchRepository.findById(matchId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.MATCH_NOT_FOUND));
 	}
 
-	/**
-	 * 리그 조회 (존재하지 않으면 예외 발생)
-	 */
-	private void fetchLeague(String leagueId, String errorMessage) {
-		leagueRepository.findById(leagueId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.LEAGUE_NOT_FOUND, errorMessage));
+	private void applyUpdates(Match match, MatchUpdateRequest request) {
+		if (request.getStartAt() != null) {
+			match.updateStartAt(request.getStartAt());
+		}
+		if (request.getStatusCode() != null) {
+			try {
+				match.updateStatus(MatchStatus.valueOf(request.getStatusCode()));
+			} catch (IllegalArgumentException e) {
+				throw new BusinessException(ErrorCode.MATCH_INVALID_STATUS);
+			}
+		}
+		if (request.getHomeScore() != null) {
+			match.updateHomeScore(request.getHomeScore());
+		}
+		if (request.getAwayScore() != null) {
+			match.updateAwayScore(request.getAwayScore());
+		}
+		if (request.getIsActive() != null) {
+			match.updateIsActive(request.getIsActive());
+		}
 	}
 
-	/**
-	 * 팀 조회 (존재하지 않으면 예외 발생)
-	 */
-	private void fetchTeam(String teamId, String errorMessage) {
-		teamRepository.findById(teamId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND, errorMessage));
-	}
-
-	/**
-	 * 스포츠 조회 (존재하지 않으면 예외 발생)
-	 */
-	private void fetchSport(String sportId, String errorMessage) {
-		sportRepository.findById(sportId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.SPORT_NOT_FOUND, errorMessage));
-	}
-
-	// ======================== 응답 변환 메서드 ========================
-
-	/**
-	 * Match -> MatchListResponse 변환
-	 */
-	private MatchListResponse toListResponseWithFetch(Match match) {
-
-		return MatchListResponse.builder()
-			.id(match.getId())
-			.sportId(match.getSportId())
-			.sportName(match.getSport() != null ? match.getSport().getEName() : "")
-			.leagueId(match.getLeagueId())
-			.leagueName(match.getLeague() != null ? match.getLeague().getEName() : "")
-			.matchType(match.getMatchType())
-			.startAt(match.getStartAt())
-			.statusCode(match.getStatusCode().name())
-			.statusName(match.getStatusCode().getDescription())
-			.homeId(match.getHomeId())
-			.homeName(match.getHomeTeam() != null ? match.getHomeTeam().getEName() : "")
-			.homeImageUrl(match.getHomeTeam() != null ? match.getHomeTeam().getImageUrl() : null)
-			.homeScore(match.getHomeScore())
-			.awayId(match.getAwayId())
-			.awayName(match.getAwayTeam() != null ? match.getAwayTeam().getEName() : "")
-			.awayImageUrl(match.getAwayTeam() != null ? match.getAwayTeam().getImageUrl() : null)
-			.awayScore(match.getAwayScore())
-			.isManual(match.isManual())
-			.isActive(match.isActive())
-			.build();
-	}
-
-	/**
-	 * Match -> MatchListResponse 변환 (기본 정보만 반환)
-	 */
-	private MatchListResponse toBasicResponse(Match match) {
-		return buildMatchResponse(match, null, null, null, null);
-	}
-
-	/**
-	 * MatchListResponse 생성
-	 */
-	private MatchListResponse buildMatchResponse(Match match,
-		League leagueEntity, Team homeTeam, Team awayTeam, Sport sportEntity) {
-
-		String leagueName = leagueEntity != null ? leagueEntity.getEName() : "";
-		String sportName = sportEntity != null ? sportEntity.getEName() : "";
-
-		return MatchListResponse.builder()
-			.id(match.getId())
-			.sportId(match.getSportId())
-			.sportName(sportName)
-			.leagueId(match.getLeagueId())
-			.leagueName(leagueName)
-			.matchType(match.getMatchType())
-			.startAt(match.getStartAt())
-			.statusCode(match.getStatusCode().name())
-			.statusName(match.getStatusCode().getDescription())
-			.homeId(match.getHomeId())
-			.homeName(homeTeam != null ? homeTeam.getEName() : "")
-			.homeImageUrl(homeTeam != null ? homeTeam.getImageUrl() : null)
-			.homeScore(match.getHomeScore())
-			.awayId(match.getAwayId())
-			.awayName(awayTeam != null ? awayTeam.getEName() : "")
-			.awayImageUrl(awayTeam != null ? awayTeam.getImageUrl() : null)
-			.awayScore(match.getAwayScore())
-			.isManual(match.isManual())
-			.isActive(match.isActive())
-			.build();
-	}
 
 
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailService.java
@@ -39,8 +39,8 @@ public class MatchDetailService {
 
     private void updateMySqlScore(String eventId, BetsViewResponse.ViewResult result) {
         matchRepository.findById(eventId).ifPresent(match -> {
-            match.setHomeScore(result.getHomeScore());
-            match.setAwayScore(result.getAwayScore());
+            match.updateHomeScore(result.getHomeScore());
+            match.updateAwayScore(result.getAwayScore());
         });
     }
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchSyncService.java
@@ -175,24 +175,24 @@ public class MatchSyncService {
 			.orElse(Match.builder().id(matchId).betsApiEventId(event.getId()).bet365Id(event.getBet365Id()).build());
 
 		// 기본 정보 업데이트
-		match.setSportId(sportId);
-		match.setLeagueId(League.generateLeagueId(sportId, event.getLeague().getId()));
-		match.setHomeId(Team.generateId(sportId, event.getHome().getId()));
-		match.setAwayId(Team.generateId(sportId, event.getAway().getId()));
-		match.setStatusCode(MatchStatus.fromCode(event.getTimeStatus()));
+		match.updateSportId(sportId);
+		match.updateLeagueId(League.generateLeagueId(sportId, event.getLeague().getId()));
+		match.updateHomeId(Team.generateId(sportId, event.getHome().getId()));
+		match.updateAwayId(Team.generateId(sportId, event.getAway().getId()));
+		match.updateStatus(MatchStatus.fromCode(event.getTimeStatus()));
 
 		// 시작 시간
 		if (event.getTime() != null) {
 			long timestamp = Long.parseLong(event.getTime());
-			match.setStartAt(LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp), DEFAULT_ZONE_ID));
+			match.updateStartAt(LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp), DEFAULT_ZONE_ID));
 		}
 
 		// 스코어
 		if (event.getSs() != null && event.getSs().contains("-")) {
 			String[] scores = event.getSs().split("-");
 			if (scores.length == 2) {
-				match.setHomeScore(Integer.parseInt(scores[0].trim()));
-				match.setAwayScore(Integer.parseInt(scores[1].trim()));
+				match.updateHomeScore(Integer.parseInt(scores[0].trim()));
+				match.updateAwayScore(Integer.parseInt(scores[1].trim()));
 			}
 		}
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/team/service/TeamCacheService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/team/service/TeamCacheService.java
@@ -1,0 +1,79 @@
+package com.scorenow.scorenow_api.domain.team.service;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.scorenow.scorenow_api.domain.team.entity.Team;
+import com.scorenow.scorenow_api.domain.team.repository.TeamRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TeamCacheService {
+
+	private static final String CACHE_PREFIX = "team:";
+	private static final Duration CACHE_TTL = Duration.ofMinutes(30);
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final TeamRepository teamRepository;
+
+	/**
+	 * 팀 조회 (캐시 우선)
+	 */
+	public Optional<Team> get(String teamId) {
+		String cacheKey = CACHE_PREFIX + teamId;
+
+		// 1. 캐시 조회
+		Team cachedTeam = (Team) redisTemplate.opsForValue().get(cacheKey);
+		if (cachedTeam != null) {
+			log.debug("Cache HIT - Team: {}", teamId);
+			return Optional.of(cachedTeam);
+		}
+
+		// 2. DB 조회
+		log.debug("Cache MISS - Team: {}", teamId);
+		Optional<Team> team = teamRepository.findById(teamId);
+
+		// 3. 캐시 저장
+		team.ifPresent(t -> {
+			redisTemplate.opsForValue().set(cacheKey, t, CACHE_TTL);
+			log.debug("Cache SET - Team: {}", teamId);
+		});
+
+		return team;
+	}
+
+	/**
+	 * 팀 캐시 삭제
+	 */
+	public void delete(String teamId) {
+		String cacheKey = CACHE_PREFIX + teamId;
+		redisTemplate.delete(cacheKey);
+		log.info("Cache DELETE - Team: {}", teamId);
+	}
+
+	/**
+	 * 전체 팀 캐시 초기화
+	 */
+	public void invalidateAll() {
+		String pattern = CACHE_PREFIX + "*";
+		var keys = redisTemplate.keys(pattern);
+		if (keys != null && !keys.isEmpty()) {
+			redisTemplate.delete(keys);
+			log.info("Cache INVALIDATE ALL - Team count: {}", keys.size());
+		}
+	}
+
+	/**
+	 * 팀 캐시 강제 갱신
+	 */
+	public Optional<Team> refresh(String teamId) {
+		delete(teamId);
+		return get(teamId);
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/global/config/QueryDslConfig.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.scorenow.scorenow_api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(){
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/global/config/RedisConfig.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/config/RedisConfig.java
@@ -1,0 +1,65 @@
+package com.scorenow.scorenow_api.global.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+	/**
+	 * RedisTemplate 설정
+	 * - Key: String (StringRedisSerializer)
+	 * - Value: JSON (GenericJackson2JsonRedisSerializer)
+	 */
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory){
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		// Key는 String으로 직렬화
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+
+		// Value는 JSON으로 직렬화
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
+		template.setValueSerializer(serializer);
+		template.setHashValueSerializer(serializer);
+
+		return template;
+	}
+
+	/**
+	 * CacheManager 설정
+	 * - TTL: 10분
+	 * - JSON: 직렬화
+	 */
+	@Bean
+	public CacheManager cacheManager(RedisConnectionFactory connectionFactory){
+		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(Duration.ofMinutes(10)) // 기본 TTL 10분
+			.serializeKeysWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+			)
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(
+					new GenericJackson2JsonRedisSerializer()
+				)
+			);
+
+		return RedisCacheManager.builder(connectionFactory)
+			.cacheDefaults(config)
+			.build();
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/global/config/SecurityConfig.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/config/SecurityConfig.java
@@ -21,6 +21,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/swagger-ui.html"
                         ).permitAll()
+                        // Admin API 접근 허용 (개발 환경)
+                        .requestMatchers("/api/admin/**").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
@@ -13,11 +13,19 @@ public enum ErrorCode {
 	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "C001", "입력값이 올바르지 않습니다."),
 	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "C002", "요청한 리소스를 찾을 수 없습니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 내부 오류가 발생했습니다."),
-	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C004", "지원하지 않는 HTTP 메서드입니다");
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C004", "지원하지 않는 HTTP 메서드입니다"),
 
 	// Match
+	MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "경기를 찾을 수 없습니다."),
+	MATCH_ALREADY_EXIST(HttpStatus.CONFLICT, "M002", "이미 존재하는 경기입니다."),
+	MATCH_INVALID_STATUS(HttpStatus.BAD_REQUEST, "M003", "잘못된 경기 상태입니다."),
+	MATCH_CANNOT_DELETE(HttpStatus.BAD_REQUEST, "M004", "삭제할 수 없는 경기입니다."),
+
+	// League
+	LEAGUE_NOT_FOUND(HttpStatus.NOT_FOUND, "L001", "리그를 찾을 수 없습니다."),
 
 	// Team
+	TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "팀을 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
@@ -25,7 +25,10 @@ public enum ErrorCode {
 	LEAGUE_NOT_FOUND(HttpStatus.NOT_FOUND, "L001", "리그를 찾을 수 없습니다."),
 
 	// Team
-	TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "팀을 찾을 수 없습니다.");
+	TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "팀을 찾을 수 없습니다."),
+
+	// Sport
+	SPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "스포츠를 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
 	MATCH_ALREADY_EXIST(HttpStatus.CONFLICT, "M002", "이미 존재하는 경기입니다."),
 	MATCH_INVALID_STATUS(HttpStatus.BAD_REQUEST, "M003", "잘못된 경기 상태입니다."),
 	MATCH_CANNOT_DELETE(HttpStatus.BAD_REQUEST, "M004", "삭제할 수 없는 경기입니다."),
+	MATCH_INVALID_TYPE(HttpStatus.BAD_REQUEST, "M005", "유효하지 않은 경기 타입입니다."),
 
 	// League
 	LEAGUE_NOT_FOUND(HttpStatus.NOT_FOUND, "L001", "리그를 찾을 수 없습니다."),

--- a/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
@@ -19,8 +19,6 @@ public enum ErrorCode {
 	MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "경기를 찾을 수 없습니다."),
 	MATCH_ALREADY_EXIST(HttpStatus.CONFLICT, "M002", "이미 존재하는 경기입니다."),
 	MATCH_INVALID_STATUS(HttpStatus.BAD_REQUEST, "M003", "잘못된 경기 상태입니다."),
-	MATCH_CANNOT_DELETE(HttpStatus.BAD_REQUEST, "M004", "삭제할 수 없는 경기입니다."),
-	MATCH_INVALID_TYPE(HttpStatus.BAD_REQUEST, "M005", "유효하지 않은 경기 타입입니다."),
 
 	// League
 	LEAGUE_NOT_FOUND(HttpStatus.NOT_FOUND, "L001", "리그를 찾을 수 없습니다."),


### PR DESCRIPTION
## #️⃣ Issue Number
> Closed #22 

## 📝 요약(Summary)
> 경기 관련 Admin API 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- JPQL -> QueryDSL로 리그명, 종목, 상태, 날짜 등 복합 검색 조건 활성화
- 경기 수동 등록/수정/삭제 API 추가
- Match 엔티티 @setter 제거 -> 명시적인 update 메서드로 엔티티 무결성 보장
- getMatches() 에서 N+1 쿼리 문제 해결(일괄 조회 + Map 매핑)
- 수동 Manual  ID는 UUID를 덧붙여 충돌나는 버그 수정
- claude 관련 문서는 무시하셔도 됩니다(제가 개인적으로 적용하는거라)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
