### PR TITLE
refactor: 라인업 teamId/teamName 추가 및 playerId 규칙 수정

### DIFF
--- a/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchLineupController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchLineupController.java
@@ -21,6 +21,7 @@ public class MatchLineupController {
 
 	private final MatchLineupService matchLineupSvc;
 
+	/** 라인업 수동 업데이트 */
 	@PatchMapping("/{matchId}/lineup/players/{playerId}")
 	public ApiResponse<String> updateLineupPlayer(
 		@PathVariable String matchId,

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupService.java
@@ -2,17 +2,23 @@ package com.scorenow.scorenow_api.domain.match.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.scorenow.scorenow_api.domain.match.document.MatchLineupDocument;
 import com.scorenow.scorenow_api.domain.match.dto.request.MatchLineupUpdateRequest;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
 import com.scorenow.scorenow_api.domain.match.model.LineupPlayer;
 import com.scorenow.scorenow_api.domain.match.model.LineupSide;
 import com.scorenow.scorenow_api.domain.match.redis.InplayRedisService;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
 import com.scorenow.scorenow_api.domain.match.repository.mongo.MatchLineupRepository;
 import com.scorenow.scorenow_api.domain.match.util.MatchIdParser;
+import com.scorenow.scorenow_api.domain.team.entity.Team;
+import com.scorenow.scorenow_api.domain.team.repository.TeamRepository;
 import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsLineupResponse;
 
@@ -27,6 +33,9 @@ public class MatchLineupService {
 	private final BetsApiClient betsApiClient;
 	private final MatchLineupRepository matchLineupRepository;
 	private final InplayRedisService redisSvc;
+
+	private final MatchRepository matchRepo;
+	private final TeamRepository teamRepo;
 
 	/* ========================= Public API - Manual ========================= */
 
@@ -157,6 +166,19 @@ public class MatchLineupService {
 			throw new IllegalArgumentException(
 				"잘못된 요청: matchId/sportId가 일치하지 않습니다. matchId=" + matchId + ", sportId=" + sportId);
 		}
+
+		Match match = matchRepo.findById(matchId)
+			.orElseThrow(() -> new IllegalArgumentException("경기가 존재하지 않습니다. matchId=" + matchId));
+
+		String homeId = match.getHomeId();
+		String awayId = match.getAwayId();
+
+		Map<String, String> eNameMap = teamRepo.findAllById(List.of(homeId, awayId)).stream()
+			.collect(Collectors.toMap(Team::getId, Team::getEName));
+
+		String homeEname = eNameMap.get(homeId);
+		String awayEname = eNameMap.get(awayId);
+
 		String eventId = MatchIdParser.extractEventId(matchId, sportId);
 		BetsLineupResponse response = betsApiClient.getLineup(eventId);
 		validateLineupResponse(response, eventId);
@@ -166,8 +188,8 @@ public class MatchLineupService {
 		MatchLineupDocument doc = matchLineupRepository.findById(matchId)
 			.orElseGet(() -> MatchLineupDocument.create(matchId));
 
-		doc.setHome(mapSide(results.getHome(), sportId));
-		doc.setAway(mapSide(results.getAway(), sportId));
+		doc.setHome(mapSide(results.getHome(), sportId, homeId, homeEname));
+		doc.setAway(mapSide(results.getAway(), sportId, awayId, awayEname));
 
 		return matchLineupRepository.save(doc);
 	}
@@ -281,41 +303,46 @@ public class MatchLineupService {
 	}
 
 	/* ========================= Internals - Mapping ========================= */
-	private LineupSide mapSide(BetsLineupResponse.BetsLineupSide ext, String sportId) {
+	private LineupSide mapSide(BetsLineupResponse.BetsLineupSide ext,
+		String sportId, String teamId, String teamEname) {
 		return LineupSide.builder()
+			.teamId(teamId)
+			.teamEname(teamEname)
 			.formation(ext.getFormation())
-			.startingLineup(mapPlayers(ext.getStartinglineup(), sportId))
-			.substitutes(mapPlayers(ext.getSubstitutes(), sportId))
+			.startingLineup(mapPlayers(ext.getStartinglineup(), teamId))
+			.substitutes(mapPlayers(ext.getSubstitutes(), teamId))
 			.build();
 	}
 
 	private List<LineupPlayer> mapPlayers(List<BetsLineupResponse.BetsLineupPlayer> extPlayers,
-		String sportId) {
+		String teamId) {
 		if (extPlayers == null) {
 			return new ArrayList<>();
 		}
 		List<LineupPlayer> list = new ArrayList<>();
 		for (BetsLineupResponse.BetsLineupPlayer ext : extPlayers) {
-			list.add(mapPlayer(ext, sportId));
+			list.add(mapPlayer(ext, teamId));
 		}
 		return list;
 	}
 
-	private LineupPlayer mapPlayer(BetsLineupResponse.BetsLineupPlayer ext, String sportId) {
-		String playerId = null;
+	private LineupPlayer mapPlayer(BetsLineupResponse.BetsLineupPlayer ext, String teamId) {
+		String playerApiId = null;
 		String eName = null;
 
 		if (ext != null && ext.getPlayer() != null) {
-			playerId = ext.getPlayer().getId();
+			playerApiId = ext.getPlayer().getId();
 			eName = ext.getPlayer().getName();
 		}
 
+		String playerId = (teamId == null || playerApiId == null) ? null : teamId + ":" + playerApiId;
+
 		return LineupPlayer.builder()
-			.playerId(playerId == null ? null : sportId + playerId)
+			.playerId(playerId)
 			.eName(eName)
 			.shirtNumber(parseIntOrNull(ext != null ? ext.getShirtnumber() : null))
 			.position(mapPosition(ext != null ? ext.getPos() : null))
-			.goals(0) // view api 연동 전
+			.goals(0)
 			.build();
 	}
 


### PR DESCRIPTION
## #️⃣ Issue Number
#42

## 📝 요약(Summary)
라인업 도큐먼트 저장 로직을 보완하고, playerId 생성 규칙을 변경했습니다.

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 코드 리팩토링

## 💬 공유사항 to 리뷰어
- 팀 정보가 도큐먼트에 저장되도록 보완했습니다. 
- playerId 생성 규칙을 기존 sportId + playerApiId에서
→ teamId:playerApiId 형식으로 변경했습니다.
→ 동일한 playerApiId가 여러 팀에 소속될 수 있는 케이스를 구분하기 위함입니다.
→ teamId 자체가 sportId + teamApiId 구조이므로, teamId:playerApiId 형태로 구성해 playerId만 보아도 소속 팀을 명확히 알 수 있도록 했습니다.
- ID 파싱 로직 통합(IdParser 전환)을 고려했으나, matchId와 playerId의 규칙이 서로 달라 도메인별로 유지하는 것이 적절하다고 판단하여 기존 MatchIdParser는 변경하지 않았습니다..

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
