### PR TITLE
feat: 선수 동기화 API 구현

### DIFF
--- a/src/main/java/com/scorenow/scorenow_api/domain/match/mapper/MatchLineupMapper.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/mapper/MatchLineupMapper.java
@@ -13,12 +13,12 @@ import com.scorenow.scorenow_api.external.betsapi.dto.BetsLineupResponse;
 public class MatchLineupMapper {
 
 	public LineupSide toSide(
-		BetsLineupResponse.BetsLineupSide ext,
+		BetsLineupResponse.LineupSide betsLineupSide,
 		String teamId,
 		String teamEname
 	) {
-		if (ext == null) {
-			// ext가 null이면 최소 구조라도 만들어두는 게 안전함
+		if (betsLineupSide == null) {
+
 			return LineupSide.builder()
 				.teamId(teamId)
 				.teamEname(teamEname)
@@ -31,30 +31,30 @@ public class MatchLineupMapper {
 		return LineupSide.builder()
 			.teamId(teamId)
 			.teamEname(teamEname)
-			.formation(ext.getFormation())
-			.startingLineup(toPlayers(ext.getStartinglineup(), teamId))
-			.substitutes(toPlayers(ext.getSubstitutes(), teamId))
+			.formation(betsLineupSide.getFormation())
+			.startingLineup(toPlayers(betsLineupSide.getStartinglineup(), teamId))
+			.substitutes(toPlayers(betsLineupSide.getSubstitutes(), teamId))
 			.build();
 	}
 
-	public List<LineupPlayer> toPlayers(List<BetsLineupResponse.BetsLineupPlayer> extPlayers, String teamId) {
-		if (extPlayers == null)
+	public List<LineupPlayer> toPlayers(List<BetsLineupResponse.LineupPlayer> betsPlayers, String teamId) {
+		if (betsPlayers == null)
 			return new ArrayList<>();
 
-		List<LineupPlayer> list = new ArrayList<>(extPlayers.size());
-		for (BetsLineupResponse.BetsLineupPlayer ext : extPlayers) {
-			list.add(toPlayer(ext, teamId));
+		List<LineupPlayer> list = new ArrayList<>(betsPlayers.size());
+		for (BetsLineupResponse.LineupPlayer betsPlayer : betsPlayers) {
+			list.add(toPlayer(betsPlayer, teamId));
 		}
 		return list;
 	}
 
-	public LineupPlayer toPlayer(BetsLineupResponse.BetsLineupPlayer ext, String teamId) {
+	public LineupPlayer toPlayer(BetsLineupResponse.LineupPlayer betsPlayer, String teamId) {
 		String playerApiId = null;
 		String eName = null;
 
-		if (ext != null && ext.getPlayer() != null) {
-			playerApiId = ext.getPlayer().getId();
-			eName = ext.getPlayer().getName();
+		if (betsPlayer != null && betsPlayer.getPlayer() != null) {
+			playerApiId = betsPlayer.getPlayer().getId();
+			eName = betsPlayer.getPlayer().getName();
 		}
 
 		String playerId = (teamId == null || playerApiId == null) ? null : teamId + ":" + playerApiId;
@@ -62,8 +62,8 @@ public class MatchLineupMapper {
 		return LineupPlayer.builder()
 			.playerId(playerId)
 			.eName(eName)
-			.shirtNumber(parseIntOrNull(ext != null ? ext.getShirtnumber() : null))
-			.position(mapPosition(ext != null ? ext.getPos() : null))
+			.shirtNumber(parseIntOrNull(betsPlayer != null ? betsPlayer.getShirtnumber() : null))
+			.position(mapPosition(betsPlayer != null ? betsPlayer.getPos() : null))
 			.goals(0)
 			.build();
 	}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupGoalsService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupGoalsService.java
@@ -11,7 +11,7 @@ import com.scorenow.scorenow_api.domain.match.document.MatchLineupDocument;
 import com.scorenow.scorenow_api.domain.match.model.LineupPlayer;
 import com.scorenow.scorenow_api.domain.match.model.LineupSide;
 import com.scorenow.scorenow_api.domain.match.repository.mongo.MatchLineupRepository;
-import com.scorenow.scorenow_api.domain.match.util.MatchIdParser;
+import com.scorenow.scorenow_api.domain.match.util.IdParser;
 import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse;
 
@@ -39,7 +39,7 @@ public class MatchLineupGoalsService {
 			return;
 
 		try {
-			String eventId = MatchIdParser.extractEventId(matchId, sportId);
+			String eventId = IdParser.extractEventId(matchId, sportId);
 
 			log.info("📡[GOALS VIEW CALL] matchId={}, sportId={}, eventId={}", matchId, sportId, eventId);
 			var viewResponse = betsApiClient.getEventView(eventId);

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupSyncService.java
@@ -12,7 +12,7 @@ import com.scorenow.scorenow_api.domain.match.entity.Match;
 import com.scorenow.scorenow_api.domain.match.mapper.MatchLineupMapper;
 import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
 import com.scorenow.scorenow_api.domain.match.repository.mongo.MatchLineupRepository;
-import com.scorenow.scorenow_api.domain.match.util.MatchIdParser;
+import com.scorenow.scorenow_api.domain.match.util.IdParser;
 import com.scorenow.scorenow_api.domain.team.entity.Team;
 import com.scorenow.scorenow_api.domain.team.repository.TeamRepository;
 import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
@@ -88,11 +88,11 @@ public class MatchLineupSyncService {
 		}
 
 		// 라인업 API 호출
-		String eventId = MatchIdParser.extractEventId(matchId, sportId);
+		String eventId = IdParser.extractEventId(matchId, sportId);
 		BetsLineupResponse response = betsApiClient.getLineup(eventId);
 		validateLineupResponse(response, eventId);
 
-		BetsLineupResponse.BetsLineupResult results = response.getResults();
+		BetsLineupResponse.Result results = response.getResults();
 
 		// match_lineups doc에 upsert
 		MatchLineupDocument doc = matchLineupRepo.findById(matchId)

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/util/IdParser.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/util/IdParser.java
@@ -1,8 +1,16 @@
 package com.scorenow.scorenow_api.domain.match.util;
 
-public class MatchIdParser {
+public class IdParser {
 
-	private MatchIdParser() {
+	private IdParser() {
+	}
+
+	/**
+	 * 내부 id에서 apiId 추출
+	 * 예: BETS194 -> 94
+	 */
+	public static String extractApiId(String internalId, String sportId) {
+		return internalId.substring(sportId.length());
 	}
 
 	/** matchId: sportId + eventId */

--- a/src/main/java/com/scorenow/scorenow_api/domain/player/controller/PlayerAdminController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/player/controller/PlayerAdminController.java
@@ -1,0 +1,4 @@
+package com.scorenow.scorenow_api.domain.player.controller;
+
+public class PlayerAdminController {
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/player/entity/Player.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/player/entity/Player.java
@@ -7,6 +7,8 @@ import com.scorenow.scorenow_api.global.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,11 +18,13 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Player extends BaseEntity {
 	@Id
-	private String id; // = teamId:playerApiId 예) BETS117230:2740907
-	private String leagueId; // 예) 프리미어리그: BETS94
-	private String teamId; // 예) BETS117230 = BETS1 + teamApiId
+	private String id;
+	private String leagueId;
+	private String teamId;
 	private String season;
 
 	private String eName;
@@ -32,6 +36,9 @@ public class Player extends BaseEntity {
 	private Integer height;
 	private String shirtnumber;
 
+	@Builder.Default
 	private boolean teaguk = false; // 태극전사
+
+	@Builder.Default
 	private boolean squadOn = true; // 스쿼드 on/off
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/player/entity/Player.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/player/entity/Player.java
@@ -1,5 +1,7 @@
 package com.scorenow.scorenow_api.domain.player.entity;
 
+import java.time.LocalDate;
+
 import com.scorenow.scorenow_api.global.entity.BaseEntity;
 
 import jakarta.persistence.Entity;
@@ -16,17 +18,20 @@ import lombok.Setter;
 @NoArgsConstructor
 public class Player extends BaseEntity {
 	@Id
-	private String id; // BETS + sportId + playerId
+	private String id; // = teamId:playerApiId 예) BETS117230:2740907
+	private String leagueId; // 예) 프리미어리그: BETS94
+	private String teamId; // 예) BETS117230 = BETS1 + teamApiId
+	private String season;
 
-	private String kName;     // 선수 이름
-	private String teamId;   // BETS + sportId + teamId (연관관계 없이 ID만 저장)
-	private String cc; // 국가코드
+	private String eName;
+	private String kName;
 
-	private String eName;     // 영문 이름
-	private String backNumber; // 등번호
+	private String cc;
+	private LocalDate birthdate;
+	private String position;
+	private Integer height;
+	private String shirtnumber;
 
-	private String birthDate; // 생년월일
-	private Double height;    // 신장(cm)
-
-	private boolean isInSquad;  // 팀 스쿼드 등록 여부
+	private boolean teaguk = false; // 태극전사
+	private boolean squadOn = true; // 스쿼드 on/off
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/player/repository/PlayerRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/player/repository/PlayerRepository.java
@@ -9,7 +9,7 @@ import com.scorenow.scorenow_api.domain.player.entity.Player;
 
 public interface PlayerRepository extends JpaRepository<Player, String> {
 
-	@Modifying
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("update Player p set p.squadOn = false where p.teamId = :teamId")
 	int setSquadOffByTeamId(@Param("teamId") String teamId);
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/player/repository/PlayerRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/player/repository/PlayerRepository.java
@@ -1,0 +1,15 @@
+package com.scorenow.scorenow_api.domain.player.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.scorenow.scorenow_api.domain.player.entity.Player;
+
+public interface PlayerRepository extends JpaRepository<Player, String> {
+
+	@Modifying
+	@Query("update Player p set p.squadOn = false where p.teamId = :teamId")
+	int setSquadOffByTeamId(@Param("teamId") String teamId);
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/player/service/LeaguePlayerSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/player/service/LeaguePlayerSyncService.java
@@ -10,31 +10,31 @@ import org.springframework.transaction.annotation.Transactional;
 import com.scorenow.scorenow_api.domain.league.entity.League;
 import com.scorenow.scorenow_api.domain.league.repository.LeagueRepository;
 import com.scorenow.scorenow_api.domain.match.util.IdParser;
-import com.scorenow.scorenow_api.domain.player.entity.Player;
-import com.scorenow.scorenow_api.domain.player.repository.PlayerRepository;
 import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
-import com.scorenow.scorenow_api.external.betsapi.dto.BetsSquadResponse;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsStandingsResponse;
 import com.scorenow.scorenow_api.global.exception.BusinessException;
 import com.scorenow.scorenow_api.global.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-public class PlayerSyncService {
+public class LeaguePlayerSyncService {
 
 	private final BetsApiClient betsApiClient;
-	private final PlayerRepository playerRepo;
-	private final LeagueRepository leagueRepo;
+	private final LeagueRepository leagueRepository;
+	private final TeamPlayerSyncService teamPlayerSyncService;
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public int syncPlayersByLeague(String leagueId) {
+
 		if (leagueId == null || leagueId.isBlank()) {
 			throw new BusinessException(ErrorCode.INVALID_PARAMETER, "leagueId가 비어있습니다.");
 		}
 
-		League league = leagueRepo.findById(leagueId)
+		League league = leagueRepository.findById(leagueId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.LEAGUE_NOT_FOUND, "리그를 찾을 수 없습니다: " + leagueId));
 
 		String sportId = league.getSportId();
@@ -55,45 +55,16 @@ public class PlayerSyncService {
 		int upsertCount = 0;
 
 		for (String teamApiId : teamApiIds) {
-			BetsSquadResponse squad = betsApiClient.getSquad(teamApiId);
-			if (squad == null || squad.getSuccess() == null || squad.getSuccess() != 1 || squad.getResults() == null) {
-				continue;
-			}
-
-			String teamId = sportId + teamApiId; // BETS1 + 17230 => BETS117230
-			playerRepo.setSquadOffByTeamId(teamId);
-			
-			for (BetsSquadResponse.SquadPlayer sp : squad.getResults()) {
-				if (sp == null || sp.getId() == null || sp.getId().isBlank())
-					continue;
-
-				Player p = new Player();
-				p.setLeagueId(leagueId);
-				p.setTeamId(teamId);
-				p.setSeason(seasonName);
-
-				// id: teamId:playerApiId
-				p.setId(teamId + ":" + sp.getId());
-
-				p.setEName(sp.getName());
-				p.setCc(sp.getCc());
-				p.setBirthdate(sp.getBirthdate());
-				p.setPosition(sp.getPosition());
-				p.setHeight(parseNullableInt(sp.getHeight()));
-				p.setShirtnumber(sp.getShirtnumber());
-
-				p.setSquadOn(true);
-
-				playerRepo.save(p);
-				upsertCount++;
+			try {
+				upsertCount += teamPlayerSyncService.syncTeamPlayers(leagueId, sportId, seasonName, teamApiId);
+			} catch (Exception e) {
+				// 팀 하나 실패해도 다음 팀 진행
+				log.warn("팀 선수 동기화 실패. leagueId={}, teamApiId={}, cause={}",
+					leagueId, teamApiId, e.toString(), e);
 			}
 		}
-
 		return upsertCount;
-
 	}
-
-	/** ========================================================== */
 
 	private String extractSeasonName(BetsStandingsResponse standings) {
 		List<BetsStandingsResponse.Result> results = standings.getResults();
@@ -126,28 +97,13 @@ public class PlayerSyncService {
 						continue;
 
 					String teamApiId = row.getTeam().getId();
-					if (teamApiId != null && !teamApiId.isBlank())
+					if (teamApiId != null && !teamApiId.isBlank()) {
 						ids.add(teamApiId.trim());
+					}
 				}
 			}
 		}
-
 		return ids;
-	}
-
-	private Integer parseNullableInt(String raw) {
-		if (raw == null)
-			return null;
-
-		String s = raw.trim();
-		if (s.isEmpty())
-			return null;
-
-		try {
-			return Integer.valueOf(s);
-		} catch (NumberFormatException e) {
-			return null;
-		}
 	}
 
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/player/service/PlayerSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/player/service/PlayerSyncService.java
@@ -1,0 +1,153 @@
+package com.scorenow.scorenow_api.domain.player.service;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueRepository;
+import com.scorenow.scorenow_api.domain.match.util.IdParser;
+import com.scorenow.scorenow_api.domain.player.entity.Player;
+import com.scorenow.scorenow_api.domain.player.repository.PlayerRepository;
+import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsSquadResponse;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsStandingsResponse;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PlayerSyncService {
+
+	private final BetsApiClient betsApiClient;
+	private final PlayerRepository playerRepo;
+	private final LeagueRepository leagueRepo;
+
+	@Transactional
+	public int syncPlayersByLeague(String leagueId) {
+		if (leagueId == null || leagueId.isBlank()) {
+			throw new BusinessException(ErrorCode.INVALID_PARAMETER, "leagueId가 비어있습니다.");
+		}
+
+		League league = leagueRepo.findById(leagueId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.LEAGUE_NOT_FOUND, "리그를 찾을 수 없습니다: " + leagueId));
+
+		String sportId = league.getSportId();
+		String leagueApiId = IdParser.extractApiId(leagueId, sportId);
+
+		BetsStandingsResponse standings = betsApiClient.getStandings(leagueApiId);
+		if (standings == null || standings.getSuccess() == null || standings.getSuccess() != 1) {
+			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "팀순위(standings) 조회에 실패했습니다.");
+		}
+
+		String seasonName = extractSeasonName(standings);
+
+		Set<String> teamApiIds = extractTeamApiIds(standings);
+		if (teamApiIds.isEmpty()) {
+			return 0;
+		}
+
+		int upsertCount = 0;
+
+		for (String teamApiId : teamApiIds) {
+			BetsSquadResponse squad = betsApiClient.getSquad(teamApiId);
+			if (squad == null || squad.getSuccess() == null || squad.getSuccess() != 1 || squad.getResults() == null) {
+				continue;
+			}
+
+			String teamId = sportId + teamApiId; // BETS1 + 17230 => BETS117230
+			playerRepo.setSquadOffByTeamId(teamId);
+			
+			for (BetsSquadResponse.SquadPlayer sp : squad.getResults()) {
+				if (sp == null || sp.getId() == null || sp.getId().isBlank())
+					continue;
+
+				Player p = new Player();
+				p.setLeagueId(leagueId);
+				p.setTeamId(teamId);
+				p.setSeason(seasonName);
+
+				// id: teamId:playerApiId
+				p.setId(teamId + ":" + sp.getId());
+
+				p.setEName(sp.getName());
+				p.setCc(sp.getCc());
+				p.setBirthdate(sp.getBirthdate());
+				p.setPosition(sp.getPosition());
+				p.setHeight(parseNullableInt(sp.getHeight()));
+				p.setShirtnumber(sp.getShirtnumber());
+
+				p.setSquadOn(true);
+
+				playerRepo.save(p);
+				upsertCount++;
+			}
+		}
+
+		return upsertCount;
+
+	}
+
+	/** ========================================================== */
+
+	private String extractSeasonName(BetsStandingsResponse standings) {
+		List<BetsStandingsResponse.Result> results = standings.getResults();
+		if (results == null || results.isEmpty())
+			return null;
+
+		BetsStandingsResponse.Result r = results.get(0);
+		if (r == null || r.getSeason() == null)
+			return null;
+
+		return r.getSeason().getName();
+	}
+
+	private Set<String> extractTeamApiIds(BetsStandingsResponse standings) {
+		Set<String> ids = new LinkedHashSet<>();
+		List<BetsStandingsResponse.Result> results = standings.getResults();
+		if (results == null)
+			return ids;
+
+		for (BetsStandingsResponse.Result r : results) {
+			if (r == null || r.getOverall() == null || r.getOverall().getTables() == null)
+				continue;
+
+			for (BetsStandingsResponse.Table t : r.getOverall().getTables()) {
+				if (t == null || t.getRows() == null)
+					continue;
+
+				for (BetsStandingsResponse.Row row : t.getRows()) {
+					if (row == null || row.getTeam() == null)
+						continue;
+
+					String teamApiId = row.getTeam().getId();
+					if (teamApiId != null && !teamApiId.isBlank())
+						ids.add(teamApiId.trim());
+				}
+			}
+		}
+
+		return ids;
+	}
+
+	private Integer parseNullableInt(String raw) {
+		if (raw == null)
+			return null;
+
+		String s = raw.trim();
+		if (s.isEmpty())
+			return null;
+
+		try {
+			return Integer.valueOf(s);
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/player/service/TeamPlayerSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/player/service/TeamPlayerSyncService.java
@@ -1,0 +1,96 @@
+package com.scorenow.scorenow_api.domain.player.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.scorenow.scorenow_api.domain.player.entity.Player;
+import com.scorenow.scorenow_api.domain.player.repository.PlayerRepository;
+import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsSquadResponse;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TeamPlayerSyncService {
+
+	private final BetsApiClient betsApiClient;
+	private final PlayerRepository playerRepo;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public int syncTeamPlayers(String leagueId, String sportId, String seasonName, String teamApiId) {
+
+		BetsSquadResponse squad = betsApiClient.getSquad(teamApiId);
+		if (!isValidSquad(squad)) {
+			throw new BusinessException(
+				ErrorCode.INTERNAL_SERVER_ERROR,
+				"스쿼드 응답이 유효하지 않습니다. teamApiId=" + teamApiId
+			);
+		}
+
+		if (squad.getResults().isEmpty()) {
+			throw new BusinessException(
+				ErrorCode.INTERNAL_SERVER_ERROR,
+				"스쿼드 결과가 비어있습니다. teamApiId=" + teamApiId
+			);
+		}
+
+		String teamId = sportId + teamApiId; // BETS1 + 17230 => BETS117230
+		playerRepo.setSquadOffByTeamId(teamId);
+
+		List<Player> toSave = new ArrayList<>(squad.getResults().size());
+		for (BetsSquadResponse.SquadPlayer sp : squad.getResults()) {
+			if (sp == null || sp.getId() == null || sp.getId().isBlank())
+				continue;
+
+			Player p = Player.builder()
+				.id(teamId + ":" + sp.getId())
+				.leagueId(leagueId)
+				.teamId(teamId)
+				.season(seasonName)
+				.eName(sp.getName())
+				.cc(sp.getCc())
+				.birthdate(sp.getBirthdate())
+				.position(sp.getPosition())
+				.height(parseNullableInt(sp.getHeight()))
+				.shirtnumber(sp.getShirtnumber())
+				.squadOn(true)
+				.build();
+
+			toSave.add(p);
+		}
+
+		playerRepo.saveAll(toSave);
+		return toSave.size();
+
+	}
+
+	private boolean isValidSquad(BetsSquadResponse squad) {
+		return squad != null
+			&& squad.getSuccess() != null
+			&& squad.getSuccess() == 1
+			&& squad.getResults() != null;
+	}
+
+	private Integer parseNullableInt(String raw) {
+		if (raw == null)
+			return null;
+
+		String s = raw.trim();
+		if (s.isEmpty())
+			return null;
+
+		try {
+			return Integer.valueOf(s);
+		} catch (NumberFormatException e) {
+			return null;
+		}
+
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/BetsApiClient.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/BetsApiClient.java
@@ -7,6 +7,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsEventResponse;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsLeagueResponse;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsLineupResponse;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsSquadResponse;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsStandingsResponse;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsTeamResponse;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse;
 
@@ -100,6 +102,9 @@ public class BetsApiClient {
 		return restTemplate.getForObject(url, BetsViewResponse.class);
 	}
 
+	/**
+	 * 라인업 조회
+	 */
 	public BetsLineupResponse getLineup(String eventId) {
 		String url = buildUrl("/v4/event/lineup")
 			.queryParam("event_id", eventId)
@@ -107,6 +112,30 @@ public class BetsApiClient {
 
 		log.debug("BetsAPI 호출: {}", maskToken(url));
 		return restTemplate.getForObject(url, BetsLineupResponse.class);
+	}
+
+	/**
+	 * 팀순위 조회
+	 */
+	public BetsStandingsResponse getStandings(String leagueId) {
+		String url = buildUrl("/v4/league/table")
+			.queryParam("league_id", leagueId)
+			.build().toUriString();
+
+		log.debug("BetsAPI 호출: {}", maskToken(url));
+		return restTemplate.getForObject(url, BetsStandingsResponse.class);
+	}
+
+	/**
+	 * 스쿼드 조회
+	 */
+	public BetsSquadResponse getSquad(String teamId) {
+		String url = buildUrl("/v4/team/squad")
+			.queryParam("team_id", teamId)
+			.build().toUriString();
+
+		log.debug("BetsAPI 호출: {}", maskToken(url));
+		return restTemplate.getForObject(url, BetsSquadResponse.class);
 	}
 
 	/**

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/controller/BetsApiTestController.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/controller/BetsApiTestController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.scorenow.scorenow_api.domain.match.service.MatchSyncService;
+import com.scorenow.scorenow_api.domain.player.service.PlayerSyncService;
 import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsEventResponse;
 import com.scorenow.scorenow_api.global.dto.ApiResponse;
@@ -22,6 +23,8 @@ public class BetsApiTestController {
 
 	private final BetsApiClient betsApiClient;
 	private final MatchSyncService matchSyncService;
+
+	private final PlayerSyncService playerSyncService;
 
 	@GetMapping("/upcoming")
 	public ApiResponse<BetsEventResponse> testUpcoming(
@@ -63,6 +66,16 @@ public class BetsApiTestController {
 		@RequestParam(required = false) String day
 	) {
 		int count = matchSyncService.syncEndedMatches(sportId, day);
+		return ApiResponse.success(count + "건 동기화 완료");
+	}
+
+	/**
+	 * 선수 동기화
+	 * curl -X POST "http://localhost:8080/api/test/betsapi/sync/players?leagueId=BETS194"
+	 */
+	@PostMapping("/sync/players")
+	public ApiResponse<String> syncPlayer(@RequestParam String leagueId) {
+		int count = playerSyncService.syncPlayersByLeague(leagueId);
 		return ApiResponse.success(count + "건 동기화 완료");
 	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/controller/BetsApiTestController.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/controller/BetsApiTestController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.scorenow.scorenow_api.domain.match.service.MatchSyncService;
-import com.scorenow.scorenow_api.domain.player.service.PlayerSyncService;
+import com.scorenow.scorenow_api.domain.player.service.LeaguePlayerSyncService;
 import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsEventResponse;
 import com.scorenow.scorenow_api.global.dto.ApiResponse;
@@ -23,8 +23,7 @@ public class BetsApiTestController {
 
 	private final BetsApiClient betsApiClient;
 	private final MatchSyncService matchSyncService;
-
-	private final PlayerSyncService playerSyncService;
+	private final LeaguePlayerSyncService leaguePlayerSyncService;
 
 	@GetMapping("/upcoming")
 	public ApiResponse<BetsEventResponse> testUpcoming(
@@ -75,7 +74,7 @@ public class BetsApiTestController {
 	 */
 	@PostMapping("/sync/players")
 	public ApiResponse<String> syncPlayer(@RequestParam String leagueId) {
-		int count = playerSyncService.syncPlayersByLeague(leagueId);
+		int count = leaguePlayerSyncService.syncPlayersByLeague(leagueId);
 		return ApiResponse.success(count + "건 동기화 완료");
 	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsLineupResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsLineupResponse.java
@@ -10,38 +10,38 @@ import lombok.Setter;
 public class BetsLineupResponse {
 
 	private Integer success;
-	private BetsLineupResult results;
+	private Result results;
 
 	@Getter
 	@Setter
-	public static class BetsLineupResult {
-		private BetsLineupSide home;
-		private BetsLineupSide away;
+	public static class Result {
+		private LineupSide home;
+		private LineupSide away;
 	}
 
 	@Getter
 	@Setter
-	public static class BetsLineupSide {
+	public static class LineupSide {
 		private String formation;
-		private List<BetsLineupPlayer> startinglineup;
-		private List<BetsLineupPlayer> substitutes;
+		private List<LineupPlayer> startinglineup;
+		private List<LineupPlayer> substitutes;
 	}
 
 	@Getter
 	@Setter
-	public static class BetsLineupPlayer {
+	public static class LineupPlayer {
 
-		private ExternalPlayer player;
+		private Player player;
 		private String shirtnumber;
 		private String pos;
+	}
 
-		@Getter
-		@Setter
-		public static class ExternalPlayer {
-			private String id;
-			private String name;
-			private String cc;
-		}
+	@Getter
+	@Setter
+	public static class Player {
+		private String id;
+		private String name;
+		private String cc;
 	}
 }
 

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsSquadResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsSquadResponse.java
@@ -1,0 +1,32 @@
+package com.scorenow.scorenow_api.external.betsapi.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BetsSquadResponse {
+
+	private Integer success;
+	private List<SquadPlayer> results;
+
+	@Getter
+	@Setter
+	public static class SquadPlayer {
+		private String id;
+		private String name;
+		private String cc;
+
+		@JsonFormat(pattern = "yyyy-MM-dd")
+		private LocalDate birthdate;
+
+		private String position;
+		private String height;
+		private String shirtnumber;
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsStandingsResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsStandingsResponse.java
@@ -1,0 +1,51 @@
+package com.scorenow.scorenow_api.external.betsapi.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BetsStandingsResponse {
+
+	private Integer success;
+	private List<Result> results;
+
+	@Getter
+	@Setter
+	public static class Result {
+		private Season season;
+		private Overall overall;
+	}
+
+	@Getter
+	@Setter
+	public static class Season {
+		private String name;
+	}
+
+	@Getter
+	@Setter
+	public static class Overall {
+		private List<Table> tables;
+	}
+
+	@Getter
+	@Setter
+	public static class Table {
+		private List<Row> rows;
+	}
+
+	@Getter
+	@Setter
+	public static class Row {
+		private Team team;
+	}
+
+	@Getter
+	@Setter
+	public static class Team {
+		private String id;
+	}
+}


### PR DESCRIPTION
## #️⃣ Issue Number
#47

## 📝 요약(Summary)
Bets API의 standings, squad API를 이용하여 리그 기준 선수 정보를 동기화하는 API를 구현했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
리그 ID를 기준으로 standings API를 통해 팀 목록을 조회하고,  
각 팀의 squad API를 호출하여 선수 정보를 동기화하도록 구현했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
