### PR TITLE
feat: INPLAY 경기 동기화 기능 개발

### DIFF
--- a/src/main/java/com/scorenow/scorenow_api/domain/match/constant/MatchConstants.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/constant/MatchConstants.java
@@ -1,0 +1,11 @@
+package com.scorenow.scorenow_api.domain.match.constant;
+
+public final class MatchConstants {
+    private MatchConstants() {
+    }
+
+    public static final String SEOUL_TIME_ZONE = "Asia/Seoul";
+    public static final String INPLAY_CANDIDATES_KEY = "inplay_candidates";
+    public static final long INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS = 1L;
+    public static final long MAX_GRACE_PERIOD_MINUTES = 15L;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/MatchCandidate.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/MatchCandidate.java
@@ -1,0 +1,24 @@
+package com.scorenow.scorenow_api.domain.match.dto;
+
+import com.scorenow.scorenow_api.external.common.ApiProvider;
+import lombok.EqualsAndHashCode;
+import lombok.EqualsAndHashCode.Include;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class MatchCandidate {
+    @Include
+    private final Long matchId;
+    private final Long sportId;
+
+    private final ApiProvider provider;
+    private final String apiMatchId;
+    private final String apiSportId;
+
+    private final LocalDateTime startAt;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/MatchCandidate.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/MatchCandidate.java
@@ -1,24 +1,23 @@
 package com.scorenow.scorenow_api.domain.match.dto;
 
 import com.scorenow.scorenow_api.external.common.ApiProvider;
-import lombok.EqualsAndHashCode;
+import lombok.*;
 import lombok.EqualsAndHashCode.Include;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class MatchCandidate {
     @Include
-    private final Long matchId;
-    private final Long sportId;
+    private Long matchId;
+    private Long sportId;
 
-    private final ApiProvider provider;
-    private final String apiMatchId;
-    private final String apiSportId;
+    private ApiProvider provider;
+    private String apiMatchId;
+    private String apiSportId;
 
-    private final LocalDateTime startAt;
+    private LocalDateTime startAt;
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
@@ -1,9 +1,12 @@
 package com.scorenow.scorenow_api.domain.match.repository.jpa;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.scorenow.scorenow_api.domain.match.dto.MatchCandidate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,44 +17,65 @@ import com.scorenow.scorenow_api.external.common.ApiProvider;
 
 public interface MatchRepository extends JpaRepository<Match, Long>, MatchRepositoryCustom {
 
-	List<Match> findByStatusCode(MatchStatus statusCode);
+    List<Match> findByStatusCode(MatchStatus statusCode);
 
-	@Query("""
-			select new com.scorenow.scorenow_api.domain.match.dto.InplayScanDto(
-				m.id,
-				m.apiMatchId,
-				m.sportId,
-				h.id,
-				h.eName,
-				hem.apiTeamId,
-				a.id,
-				a.eName,
-				aem.apiTeamId
-			)
-			from Match m
-			join Team h on h.id = m.homeId
-			join Team a on a.id = m.awayId
-			join TeamExternalMapping hem
-				on hem.internalTeamId = h.id
-				and hem.provider = m.provider
-			join TeamExternalMapping aem
-				on aem.internalTeamId = a.id
-				and aem.provider = m.provider
-			where m.statusCode = :status
-			  and m.isActive = true
-		""")
-	List<InplayScanDto> findInplayMatchDtos(@Param("status") MatchStatus status);
+    @Query("""
+            	select new com.scorenow.scorenow_api.domain.match.dto.InplayScanDto(
+            		m.id,
+            		m.apiMatchId,
+            		m.sportId,
+            		h.id,
+            		h.eName,
+            		hem.apiTeamId,
+            		a.id,
+            		a.eName,
+            		aem.apiTeamId
+            	)
+            	from Match m
+            	join Team h on h.id = m.homeId
+            	join Team a on a.id = m.awayId
+            	join TeamExternalMapping hem
+            		on hem.internalTeamId = h.id
+            		and hem.provider = m.provider
+            	join TeamExternalMapping aem
+            		on aem.internalTeamId = a.id
+            		and aem.provider = m.provider
+            	where m.statusCode = :status
+            	  and m.isActive = true
+            """)
+    List<InplayScanDto> findInplayMatchDtos(@Param("status") MatchStatus status);
 
-	boolean existsByIdAndStatusCode(Long id, MatchStatus statusCode);
+    boolean existsByIdAndStatusCode(Long id, MatchStatus statusCode);
 
-	@Query("""
-			select m
-			from Match m
-			where m.provider = :provider
-			  and m.apiMatchId = :apiMatchId
-		""")
-	Optional<Match> findByExternalInfo(
-		@Param("provider") ApiProvider provider,
-		@Param("apiMatchId") String apiMatchId
-	);
+    @Query("""
+            	select m
+            	from Match m
+            	where m.provider = :provider
+            	  and m.apiMatchId = :apiMatchId
+            """)
+    Optional<Match> findByExternalInfo(
+            @Param("provider") ApiProvider provider,
+            @Param("apiMatchId") String apiMatchId
+    );
+
+    @Query("""
+            	 select new com.scorenow.scorenow_api.domain.match.scheduler.MatchCandidateScheduler.MatchCandidate(
+            		m.id,
+            		m.sportId,
+            		m.provider,
+            		m.apiMatchId,
+            		sem.apiSportId
+            	)
+            	  from Match m
+            	  join SportExternalMapping sem
+            		on sem.internalSportId = m.sportId
+            	  where m.statusCode = :matchStatus
+            		and m.startAt between :now and :targetTime
+            		and m.isManual = false
+            """)
+    List<MatchCandidate> findMatchesStartingWithin(MatchStatus matchStatus, LocalDateTime now, LocalDateTime targetTime);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Match m set m.status = :status, m.updatedAt = CURRENT_TIMESTAMP where m.id IN :matchIds")
+    void updateStatusBulk(List<Long> matchIds, MatchStatus status);
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
@@ -70,10 +70,10 @@ public interface MatchRepository extends JpaRepository<Match, Long>, MatchReposi
             	  join SportExternalMapping sem
             		on sem.internalSportId = m.sportId
             	  where m.statusCode = :matchStatus
-            		and m.startAt between :now and :targetTime
+            		and m.startAt between :startAt and :targetTime
             		and m.isManual = false
             """)
-    List<MatchCandidate> findMatchesStartingWithin(MatchStatus matchStatus, LocalDateTime now, LocalDateTime targetTime);
+    List<MatchCandidate> findMatchesStartingWithin(MatchStatus matchStatus, LocalDateTime startAt, LocalDateTime targetTime);
 
     @Modifying(clearAutomatically = true)
     @Query("update Match m set m.status = :status, m.updatedAt = CURRENT_TIMESTAMP where m.id IN :matchIds")

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
@@ -59,12 +59,13 @@ public interface MatchRepository extends JpaRepository<Match, Long>, MatchReposi
     );
 
     @Query("""
-            	 select new com.scorenow.scorenow_api.domain.match.scheduler.MatchCandidateScheduler.MatchCandidate(
+            	 select new com.scorenow.scorenow_api.domain.match.dto.MatchCandidate(
             		m.id,
             		m.sportId,
             		m.provider,
             		m.apiMatchId,
-            		sem.apiSportId
+            		sem.apiSportId,
+                    m.startAt
             	)
             	  from Match m
             	  join SportExternalMapping sem
@@ -76,6 +77,6 @@ public interface MatchRepository extends JpaRepository<Match, Long>, MatchReposi
     List<MatchCandidate> findMatchesStartingWithin(MatchStatus matchStatus, LocalDateTime startAt, LocalDateTime targetTime);
 
     @Modifying(clearAutomatically = true)
-    @Query("update Match m set m.status = :status, m.updatedAt = CURRENT_TIMESTAMP where m.id IN :matchIds")
+    @Query("update Match m set m.statusCode = :status, m.updatedAt = CURRENT_TIMESTAMP where m.id IN :matchIds")
     void updateStatusBulk(List<Long> matchIds, MatchStatus status);
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/redis/InplayMatchRedisRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/redis/InplayMatchRedisRepository.java
@@ -22,13 +22,13 @@ public class InplayMatchRedisRepository {
     private final RedisTemplate<String, Object> redisTemplate;
 
     public void addCandidate(MatchCandidate candidate, ZonedDateTime startAt) {
-        double score = (double) startAt.toInstant().toEpochMilli();
+        double score = (double) startAt.toEpochSecond();
         redisTemplate.opsForZSet().addIfAbsent(INPLAY_CANDIDATES_KEY, candidate, score);
     }
 
     public List<MatchCandidate> findCandidatesToSync(ZonedDateTime now) {
         Set<Object> matchCandidates = redisTemplate.opsForZSet()
-                .rangeByScore(INPLAY_CANDIDATES_KEY, 0, (double) now.plusSeconds(1).toInstant().toEpochMilli());
+                .rangeByScore(INPLAY_CANDIDATES_KEY, 0, (double) now.plusSeconds(1).toEpochSecond());
 
         if (matchCandidates == null || matchCandidates.isEmpty()) {
             log.info("{} 기준 시작 여부 검증 대상 경기가 없습니다. ❌", now);
@@ -41,6 +41,7 @@ public class InplayMatchRedisRepository {
     }
 
     public void removeCandidates(List<MatchCandidate> targets) {
+        if (targets.isEmpty()) return;
         redisTemplate.opsForZSet().remove(INPLAY_CANDIDATES_KEY, targets.toArray());
     }
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/redis/InplayMatchRedisRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/redis/InplayMatchRedisRepository.java
@@ -1,0 +1,46 @@
+package com.scorenow.scorenow_api.domain.match.repository.redis;
+
+import com.scorenow.scorenow_api.domain.match.dto.MatchCandidate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static com.scorenow.scorenow_api.domain.match.constant.MatchConstants.INPLAY_CANDIDATES_KEY;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class InplayMatchRedisRepository {
+
+    // { key:inplay_candidates / value:MatchCandidate / score:경기시작시간 }
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void addCandidate(MatchCandidate candidate, ZonedDateTime startAt) {
+        double score = (double) startAt.toInstant().toEpochMilli();
+        redisTemplate.opsForZSet().addIfAbsent(INPLAY_CANDIDATES_KEY, candidate, score);
+    }
+
+    public List<MatchCandidate> findCandidatesToSync(ZonedDateTime now) {
+        Set<Object> matchCandidates = redisTemplate.opsForZSet()
+                .rangeByScore(INPLAY_CANDIDATES_KEY, 0, (double) now.plusSeconds(1).toInstant().toEpochMilli());
+
+        if (matchCandidates == null || matchCandidates.isEmpty()) {
+            log.info("{} 기준 시작 여부 검증 대상 경기가 없습니다. ❌", now);
+            return Collections.emptyList();
+        }
+
+        return matchCandidates.stream()
+                .map(obj -> (MatchCandidate) obj)
+                .toList();
+    }
+
+    public void removeCandidates(List<MatchCandidate> targets) {
+        redisTemplate.opsForZSet().remove(INPLAY_CANDIDATES_KEY, targets.toArray());
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchSyncScheduler.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchSyncScheduler.java
@@ -2,6 +2,8 @@ package com.scorenow.scorenow_api.domain.match.scheduler;
 
 import java.time.LocalDateTime;
 
+import com.scorenow.scorenow_api.domain.match.service.InplayMatchCandidateLoadService;
+import com.scorenow.scorenow_api.domain.match.service.InplayMatchSyncService;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
@@ -21,46 +23,79 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MatchSyncScheduler {
 
-	private static final String FOOTBALL = "1";
+    private static final String FOOTBALL = "1";
 
-	private final JobLauncher jobLauncher;
-	private final Job matchSyncJob;
-	private final MatchSyncService matchSyncService;
+    private final JobLauncher jobLauncher;
+    private final Job matchSyncJob;
+    private final MatchSyncService matchSyncService;
 
-	/**
-	 * 매일 2회 배치 실행(4시, 16시)
-	 * 테스트 시 임시 사용: @Scheduled(initialDelay = 10000, fixedRate = 1000000)
-	 */
-	@Scheduled(cron = "0 0 4,16 * * *")
-	public void runMatchSyncJob() {
-		log.info("=== Match Sync Batch Job 시작 ===");
+    private final InplayMatchCandidateLoadService inplayMatchCandidateLoadService;
+    private final InplayMatchSyncService inplayMatchSyncService;
 
-		try {
-			JobParameters params = new JobParametersBuilder()
-				.addString("runTime", LocalDateTime.now().toString())
-				.toJobParameters();
+    /**
+     * 매일 2회 배치 실행(4시, 16시)
+     * 테스트 시 임시 사용: @Scheduled(initialDelay = 10000, fixedRate = 1000000)
+     */
+    @Scheduled(cron = "0 0 4,16 * * *")
+    public void runMatchSyncJob() {
+        log.info("=== Match Sync Batch Job 시작 ===");
 
-			jobLauncher.run(matchSyncJob, params);
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addString("runTime", LocalDateTime.now().toString())
+                    .toJobParameters();
 
-			log.info("=== Match Sync Batch Job 완료 ===");
-		} catch (Exception e) {
-			log.error("Batch Job 실패", e);
-		}
-	}
+            jobLauncher.run(matchSyncJob, params);
 
-	/**
-	 * Ended - 10분마다 (오늘 경기만, 종료 후 30분 내 반영)
-	 */
-	@Scheduled(fixedDelay = 600000)
-	public void syncEndedMatches() {
-		log.info("=== [ENDED] 종료 경기 동기화 ===");
+            log.info("=== Match Sync Batch Job 완료 ===");
+        } catch (Exception e) {
+            log.error("Batch Job 실패", e);
+        }
+    }
 
-		try {
-			int count = matchSyncService.syncEndedMatches(FOOTBALL, null);
-			log.info("[ENDED] 동기화 완료 - {}건", count);
-		} catch (Exception e) {
-			log.error("[ENDED] 동기화 실패", e);
-		}
-	}
+    /**
+     * Ended - 10분마다 (오늘 경기만, 종료 후 30분 내 반영)
+     */
+    @Scheduled(fixedDelay = 600000)
+    public void syncEndedMatches() {
+        log.info("=== [ENDED] 종료 경기 동기화 ===");
+
+        try {
+            int count = matchSyncService.syncEndedMatches(FOOTBALL, null);
+            log.info("[ENDED] 동기화 완료 - {}건", count);
+        } catch (Exception e) {
+            log.error("[ENDED] 동기화 실패", e);
+        }
+    }
+
+    /**
+     * 작업 내용 : 현재 시간 기준 향후 1시간 이내 시작 예정인 경기들을 조회 후 캐싱
+     * 작업 주기 : 매 시 정각과 30분
+     */
+    @Scheduled(cron = "0 0/30 * * * *")
+    public void loadInplayCandidatesToCache() {
+        log.info("📅 INPLAY 예정 경기 캐싱 시작");
+
+        try {
+            inplayMatchCandidateLoadService.loadInplayCandidatesToCache();
+        } catch (Exception e) {
+            log.error("시작 예정 경기 캐싱 작업 중 예외 발생 ❌", e);
+        }
+    }
+
+    /**
+     * 작업 내용 : Redis ZSet 에 저장한 1시간 이내 시작 예정인 경기 중, 경기 시작한 건에 대해서 외부 API 를 호출을 통한 동기화 작업을 진행
+     * 작업 주기 : 매 분 (1분 마다)
+     */
+    @Scheduled(cron = "0 * * * * *")
+    public void syncInplayMatches() {
+        log.info("📅 INPLAY 경기 동기화 시작");
+
+        try {
+            inplayMatchSyncService.syncInplayMatches();
+        } catch (Exception e) {
+            log.error("INPLAY 경기 동기화 처리 중 예외 발생 ❌", e);
+        }
+    }
 
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchSyncScheduler.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchSyncScheduler.java
@@ -77,7 +77,7 @@ public class MatchSyncScheduler {
         log.info("📅 INPLAY 예정 경기 캐싱 시작");
 
         try {
-            inplayMatchCandidateLoadService.loadInplayCandidatesToCache();
+            inplayMatchCandidateLoadService.loadInplayCandidatesToCache(LocalDateTime.now());
         } catch (Exception e) {
             log.error("시작 예정 경기 캐싱 작업 중 예외 발생 ❌", e);
         }
@@ -92,7 +92,7 @@ public class MatchSyncScheduler {
         log.info("📅 INPLAY 경기 동기화 시작");
 
         try {
-            inplayMatchSyncService.syncInplayMatches();
+            inplayMatchSyncService.syncInplayMatches(LocalDateTime.now());
         } catch (Exception e) {
             log.error("INPLAY 경기 동기화 처리 중 예외 발생 ❌", e);
         }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
@@ -1,0 +1,37 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import com.scorenow.scorenow_api.domain.match.dto.MatchCandidate;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static com.scorenow.scorenow_api.domain.match.constant.MatchConstants.*;
+import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.NOT_STARTED;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InplayMatchCandidateLoadService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final MatchRepository matchRepository;
+
+    public void loadInplayCandidatesToCache() {
+        ZonedDateTime now = LocalDateTime.now().atZone(ZoneId.of(SEOUL_TIME_ZONE));
+        List<MatchCandidate> candidates = matchRepository.findMatchesStartingWithin(NOT_STARTED, now.toLocalDateTime(), now.toLocalDateTime().plusHours(INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS));
+
+        log.info("{}시간 이내 시작 예정 경기 건수 : {}", INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS, candidates.size());
+
+        for (MatchCandidate candidate : candidates) {
+            // ZSet : { key:inplay_candidates / value:MatchCandidate / score:경기시작시간 }
+            redisTemplate.opsForZSet().addIfAbsent(INPLAY_CANDIDATES_KEY, candidate, (double) now.toInstant().toEpochMilli());
+        }
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
@@ -2,9 +2,9 @@ package com.scorenow.scorenow_api.domain.match.service;
 
 import com.scorenow.scorenow_api.domain.match.dto.MatchCandidate;
 import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import com.scorenow.scorenow_api.domain.match.repository.redis.InplayMatchRedisRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -19,19 +19,19 @@ import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.NOT_STAR
 @Service
 @RequiredArgsConstructor
 public class InplayMatchCandidateLoadService {
-
-    private final RedisTemplate<String, Object> redisTemplate;
+    private static final ZoneId SEOUL_TIME_ZONE_ID = ZoneId.of(SEOUL_TIME_ZONE);
     private final MatchRepository matchRepository;
+    private final InplayMatchRedisRepository inplayMatchRedisRepository;
 
     public void loadInplayCandidatesToCache() {
-        ZonedDateTime now = LocalDateTime.now().atZone(ZoneId.of(SEOUL_TIME_ZONE));
+        ZonedDateTime now = LocalDateTime.now().atZone(SEOUL_TIME_ZONE_ID);
         List<MatchCandidate> candidates = matchRepository.findMatchesStartingWithin(NOT_STARTED, now.toLocalDateTime(), now.toLocalDateTime().plusHours(INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS));
 
         log.info("{}시간 이내 시작 예정 경기 건수 : {}", INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS, candidates.size());
 
         for (MatchCandidate candidate : candidates) {
-            // ZSet : { key:inplay_candidates / value:MatchCandidate / score:경기시작시간 }
-            redisTemplate.opsForZSet().addIfAbsent(INPLAY_CANDIDATES_KEY, candidate, (double) now.toInstant().toEpochMilli());
+            ZonedDateTime startAt = candidate.getStartAt().atZone(SEOUL_TIME_ZONE_ID);
+            inplayMatchRedisRepository.addCandidate(candidate, startAt);
         }
     }
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
@@ -19,7 +19,9 @@ import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.NOT_STAR
 @Service
 @RequiredArgsConstructor
 public class InplayMatchCandidateLoadService {
+
     private static final ZoneId SEOUL_TIME_ZONE_ID = ZoneId.of(SEOUL_TIME_ZONE);
+
     private final MatchRepository matchRepository;
     private final InplayMatchRedisRepository inplayMatchRedisRepository;
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
@@ -25,9 +25,11 @@ public class InplayMatchCandidateLoadService {
     private final MatchRepository matchRepository;
     private final InplayMatchRedisRepository inplayMatchRedisRepository;
 
-    public void loadInplayCandidatesToCache() {
-        ZonedDateTime now = LocalDateTime.now().atZone(SEOUL_TIME_ZONE_ID);
-        List<MatchCandidate> candidates = matchRepository.findMatchesStartingWithin(NOT_STARTED, now.toLocalDateTime(), now.toLocalDateTime().plusHours(INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS));
+    public void loadInplayCandidatesToCache(LocalDateTime standardTime) {
+        ZonedDateTime start = standardTime.atZone(SEOUL_TIME_ZONE_ID);
+        ZonedDateTime end = start.plusHours(INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS);
+
+        List<MatchCandidate> candidates = matchRepository.findMatchesStartingWithin(NOT_STARTED, start.toLocalDateTime(), end.toLocalDateTime());
 
         log.info("{}시간 이내 시작 예정 경기 건수 : {}", INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS, candidates.size());
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchStatusUpdater.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchStatusUpdater.java
@@ -4,13 +4,11 @@ import com.scorenow.scorenow_api.domain.match.dto.MatchCandidate;
 import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.scorenow.scorenow_api.domain.match.constant.MatchConstants.INPLAY_CANDIDATES_KEY;
 import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.*;
 
 @Slf4j
@@ -18,7 +16,6 @@ import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.*;
 @RequiredArgsConstructor
 public class InplayMatchStatusUpdater {
     private final MatchRepository matchRepository;
-    private final RedisTemplate<String, Object> redisTemplate;
 
     @Transactional
     public void updateMatchStatuses(List<MatchCandidate> inplayMatches, List<MatchCandidate> toBeFixedMatches) {
@@ -28,7 +25,6 @@ public class InplayMatchStatusUpdater {
                     .toList();
 
             matchRepository.updateStatusBulk(matchIds, IN_PLAY);
-            removeFromZSet(inplayMatches);
         }
 
         if (!toBeFixedMatches.isEmpty()) {
@@ -37,11 +33,7 @@ public class InplayMatchStatusUpdater {
                     .toList();
 
             matchRepository.updateStatusBulk(matchIds, TO_BE_FIXED);
-            removeFromZSet(toBeFixedMatches);
         }
     }
 
-    private void removeFromZSet(List<MatchCandidate> targets) {
-        redisTemplate.opsForZSet().remove(INPLAY_CANDIDATES_KEY, targets.toArray());
-    }
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchStatusUpdater.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchStatusUpdater.java
@@ -1,0 +1,47 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import com.scorenow.scorenow_api.domain.match.dto.MatchCandidate;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.scorenow.scorenow_api.domain.match.constant.MatchConstants.INPLAY_CANDIDATES_KEY;
+import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InplayMatchStatusUpdater {
+    private final MatchRepository matchRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Transactional
+    public void updateMatchStatuses(List<MatchCandidate> inplayMatches, List<MatchCandidate> toBeFixedMatches) {
+        if (!inplayMatches.isEmpty()) {
+            List<Long> matchIds = inplayMatches.stream()
+                    .map(MatchCandidate::getMatchId)
+                    .toList();
+
+            matchRepository.updateStatusBulk(matchIds, IN_PLAY);
+            removeFromZSet(inplayMatches);
+        }
+
+        if (!toBeFixedMatches.isEmpty()) {
+            List<Long> matchIds = toBeFixedMatches.stream()
+                    .map(MatchCandidate::getMatchId)
+                    .toList();
+
+            matchRepository.updateStatusBulk(matchIds, TO_BE_FIXED);
+            removeFromZSet(toBeFixedMatches);
+        }
+    }
+
+    private void removeFromZSet(List<MatchCandidate> targets) {
+        redisTemplate.opsForZSet().remove(INPLAY_CANDIDATES_KEY, targets.toArray());
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchStatusUpdater.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchStatusUpdater.java
@@ -15,6 +15,7 @@ import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.*;
 @Service
 @RequiredArgsConstructor
 public class InplayMatchStatusUpdater {
+
     private final MatchRepository matchRepository;
 
     @Transactional

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
@@ -82,7 +82,12 @@ public class InplayMatchSyncService {
         // 4. 분류 결과를 기반으로 Redis 와 DB 에 반영
         if (!inplayMatches.isEmpty() || !toBeFixedMatches.isEmpty()) {
             inplayMatchStatusUpdater.updateMatchStatuses(inplayMatches, toBeFixedMatches);
+            removeFromZSet(inplayMatches);
+            removeFromZSet(toBeFixedMatches);
         }
+    }
 
+    private void removeFromZSet(List<MatchCandidate> targets) {
+        redisTemplate.opsForZSet().remove(INPLAY_CANDIDATES_KEY, targets.toArray());
     }
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
@@ -1,11 +1,11 @@
 package com.scorenow.scorenow_api.domain.match.service;
 
 import com.scorenow.scorenow_api.domain.match.dto.MatchCandidate;
+import com.scorenow.scorenow_api.domain.match.repository.redis.InplayMatchRedisRepository;
 import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsEventResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -23,27 +23,15 @@ import static com.scorenow.scorenow_api.domain.match.constant.MatchConstants.*;
 @RequiredArgsConstructor
 public class InplayMatchSyncService {
 
-    private final RedisTemplate<String, Object> redisTemplate;
-
     private final BetsApiClient betsApiClient;
-
     private final InplayMatchStatusUpdater inplayMatchStatusUpdater;
+    private final InplayMatchRedisRepository inplayMatchRedisRepository;
 
     public void syncInplayMatches() {
         ZonedDateTime now = LocalDateTime.now().atZone(ZoneId.of(SEOUL_TIME_ZONE));
 
         // 1. 동기화 대상 조회 (현재 시간 기준 INPLAY 일 것으로 예상되는 경기들)
-        Set<Object> matchCandidates = redisTemplate.opsForZSet()
-                .rangeByScore(INPLAY_CANDIDATES_KEY, 0, (double) now.plusSeconds(1).toInstant().toEpochMilli());
-
-        if (matchCandidates == null || matchCandidates.isEmpty()) {
-            log.info("{} 기준 시작 여부 검증 대상 경기가 없습니다. ❌", now);
-            return;
-        }
-
-        List<MatchCandidate> candidates = matchCandidates.stream()
-                .map(obj -> (MatchCandidate) obj)
-                .toList();
+        List<MatchCandidate> candidates = inplayMatchRedisRepository.findCandidatesToSync(now);
 
         // 2. 외부 API 중복 호출 방지를 위해 Sport ID만 추출 (종목별 INPLAY API 호출 필요)
         List<String> apiSportIds = candidates.stream()
@@ -80,12 +68,10 @@ public class InplayMatchSyncService {
         // 5. 분류 결과를 기반으로 DB 반영 및 Redis 캐시 정리
         if (!inplayMatches.isEmpty() || !toBeFixedMatches.isEmpty()) {
             inplayMatchStatusUpdater.updateMatchStatuses(inplayMatches, toBeFixedMatches);
-            removeFromZSet(inplayMatches);
-            removeFromZSet(toBeFixedMatches);
+
+            inplayMatchRedisRepository.removeCandidates(inplayMatches);
+            inplayMatchRedisRepository.removeCandidates(toBeFixedMatches);
         }
     }
 
-    private void removeFromZSet(List<MatchCandidate> targets) {
-        redisTemplate.opsForZSet().remove(INPLAY_CANDIDATES_KEY, targets.toArray());
-    }
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
@@ -27,8 +27,8 @@ public class InplayMatchSyncService {
     private final InplayMatchStatusUpdater inplayMatchStatusUpdater;
     private final InplayMatchRedisRepository inplayMatchRedisRepository;
 
-    public void syncInplayMatches() {
-        ZonedDateTime now = LocalDateTime.now().atZone(ZoneId.of(SEOUL_TIME_ZONE));
+    public void syncInplayMatches(LocalDateTime standardTime) {
+        ZonedDateTime now = standardTime.atZone(ZoneId.of(SEOUL_TIME_ZONE));
 
         // 1. 동기화 대상 조회 (현재 시간 기준 INPLAY 일 것으로 예상되는 경기들)
         List<MatchCandidate> candidates = inplayMatchRedisRepository.findCandidatesToSync(now);

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
@@ -1,0 +1,88 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import com.scorenow.scorenow_api.domain.match.dto.MatchCandidate;
+import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsEventResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.scorenow.scorenow_api.domain.match.constant.MatchConstants.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InplayMatchSyncService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private final BetsApiClient betsApiClient;
+
+    private final InplayMatchStatusUpdater inplayMatchStatusUpdater;
+
+    public void syncInplayMatches() {
+        ZonedDateTime now = LocalDateTime.now().atZone(ZoneId.of(SEOUL_TIME_ZONE));
+
+        // 1. 현재 INPLAY 일 것으로 예상되는 경기들을 조회
+        Set<Object> matchCandidates = redisTemplate.opsForZSet()
+                .rangeByScore(INPLAY_CANDIDATES_KEY, 0, (double) now.plusSeconds(1).toInstant().toEpochMilli());
+
+        if (matchCandidates == null || matchCandidates.isEmpty()) {
+            log.info("{} 기준 시작 여부 검증 대상 경기가 없습니다. ❌", now);
+            return;
+        }
+
+        List<MatchCandidate> candidates = matchCandidates.stream()
+                .map(obj -> (MatchCandidate) obj)
+                .toList();
+
+        // 2. 외부 sportId 값만 추출 (종목이 여러 개면 각각 INPLAY API 를 호출해야 하기 때문)
+        List<String> apiSportIds = candidates.stream()
+                .map(MatchCandidate::getApiSportId)
+                .distinct()
+                .toList();
+
+        // 2. 종목 별 INPLAY API 요청 후, 응답 받은 Match ID 만 취합
+        Set<String> inplayMatchIds = apiSportIds.stream()
+                .map(sportId -> betsApiClient.getInplayEvents(sportId, null))
+                .flatMap(response -> response.getResults().stream())
+                .map(BetsEventResponse.Event::getId)
+                .collect(Collectors.toSet());
+
+        /**
+         * 3. INPLAY API 응답과 비교하며, 실제로 경기가 진행된 경기와 경기가 유예기간이 초과한 경기를 분류
+         *    참고) 유예기간이 초과한 경기:
+         *          현재 시간 기준 시작되어야 하는 경기이나 MAX_GRACE_PERIOD 만큼 대기 후에도 API 응답 상으로 여전히 시작하지 못한 경기
+         */
+        List<MatchCandidate> inplayMatches = new ArrayList<>();
+        List<MatchCandidate> toBeFixedMatches = new ArrayList<>();
+
+        for (MatchCandidate candidate : candidates) {
+            if (inplayMatchIds.contains(candidate.getApiMatchId())) {
+                inplayMatches.add(candidate);
+                continue;
+            }
+
+            LocalDateTime startAt = candidate.getStartAt();
+            if (startAt.plusMinutes(MAX_GRACE_PERIOD_MINUTES).isBefore(now.toLocalDateTime())) {
+                log.warn("유예 기간 초과. matchId:{}", candidate.getMatchId());
+                toBeFixedMatches.add(candidate);
+            }
+        }
+
+        // 4. 분류 결과를 기반으로 Redis 와 DB 에 반영
+        if (!inplayMatches.isEmpty() || !toBeFixedMatches.isEmpty()) {
+            inplayMatchStatusUpdater.updateMatchStatuses(inplayMatches, toBeFixedMatches);
+        }
+
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
@@ -32,7 +32,7 @@ public class InplayMatchSyncService {
     public void syncInplayMatches() {
         ZonedDateTime now = LocalDateTime.now().atZone(ZoneId.of(SEOUL_TIME_ZONE));
 
-        // 1. 현재 INPLAY 일 것으로 예상되는 경기들을 조회
+        // 1. 동기화 대상 조회 (현재 시간 기준 INPLAY 일 것으로 예상되는 경기들)
         Set<Object> matchCandidates = redisTemplate.opsForZSet()
                 .rangeByScore(INPLAY_CANDIDATES_KEY, 0, (double) now.plusSeconds(1).toInstant().toEpochMilli());
 
@@ -45,24 +45,22 @@ public class InplayMatchSyncService {
                 .map(obj -> (MatchCandidate) obj)
                 .toList();
 
-        // 2. 외부 sportId 값만 추출 (종목이 여러 개면 각각 INPLAY API 를 호출해야 하기 때문)
+        // 2. 외부 API 중복 호출 방지를 위해 Sport ID만 추출 (종목별 INPLAY API 호출 필요)
         List<String> apiSportIds = candidates.stream()
                 .map(MatchCandidate::getApiSportId)
                 .distinct()
                 .toList();
 
-        // 2. 종목 별 INPLAY API 요청 후, 응답 받은 Match ID 만 취합
+        // 3. 종목별 INPLAY API 호출 및 실제 진행 중인 경기 ID 취합
         Set<String> inplayMatchIds = apiSportIds.stream()
                 .map(sportId -> betsApiClient.getInplayEvents(sportId, null))
                 .flatMap(response -> response.getResults().stream())
                 .map(BetsEventResponse.Event::getId)
                 .collect(Collectors.toSet());
 
-        /**
-         * 3. INPLAY API 응답과 비교하며, 실제로 경기가 진행된 경기와 경기가 유예기간이 초과한 경기를 분류
-         *    참고) 유예기간이 초과한 경기:
-         *          현재 시간 기준 시작되어야 하는 경기이나 MAX_GRACE_PERIOD 만큼 대기 후에도 API 응답 상으로 여전히 시작하지 못한 경기
-         */
+
+        // 4. INPLAY API 응답과 대조하여 대상 분류 (진행 중, 유예기간 초과)
+        // 참고) 유예기간 초과한 경기 : 현재 시간 기준 시작돼야 하는 경기이나, 최대 유예 기간만큼 대기 후에도 API 응답 기준 여전히 시작하지 못한 경기
         List<MatchCandidate> inplayMatches = new ArrayList<>();
         List<MatchCandidate> toBeFixedMatches = new ArrayList<>();
 
@@ -79,7 +77,7 @@ public class InplayMatchSyncService {
             }
         }
 
-        // 4. 분류 결과를 기반으로 Redis 와 DB 에 반영
+        // 5. 분류 결과를 기반으로 DB 반영 및 Redis 캐시 정리
         if (!inplayMatches.isEmpty() || !toBeFixedMatches.isEmpty()) {
             inplayMatchStatusUpdater.updateMatchStatuses(inplayMatches, toBeFixedMatches);
             removeFromZSet(inplayMatches);

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
@@ -13,6 +13,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -41,7 +42,15 @@ public class InplayMatchSyncService {
 
         // 3. 종목별 INPLAY API 호출 및 실제 진행 중인 경기 ID 취합
         Set<String> inplayMatchIds = apiSportIds.stream()
-                .map(sportId -> betsApiClient.getInplayEvents(sportId, null))
+                .map(sportId -> {
+                    try {
+                        return betsApiClient.getInplayEvents(sportId, null);
+                    } catch (Exception e) {
+                        log.error("[종목ID:{}] INPLAY API 호출 실패. 해당 종목은 이번 동기화에서 제외", sportId, e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
                 .flatMap(response -> response.getResults().stream())
                 .map(BetsEventResponse.Event::getId)
                 .collect(Collectors.toSet());

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchEventSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchEventSyncService.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import com.scorenow.scorenow_api.domain.league.service.LeagueService;
+import com.scorenow.scorenow_api.domain.match.constant.MatchConstants;
 import com.scorenow.scorenow_api.domain.sport.repository.SportExternalMappingRepository;
 import com.scorenow.scorenow_api.domain.team.service.TeamService;
 import com.scorenow.scorenow_api.external.common.ApiProvider;
@@ -30,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MatchEventSyncService {
 
     private static final String TEAM_IMAGE_BASE_URL = "https://assets.b365api.com/images/team/m/";
-    private static final ZoneId DEFAULT_ZONE_ID = ZoneId.of("Asia/Seoul");
+    private static final ZoneId DEFAULT_ZONE_ID = ZoneId.of(MatchConstants.SEOUL_TIME_ZONE);
 
     private final LeagueService leagueService;
     private final TeamService teamService;

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/BetsApiClient.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/BetsApiClient.java
@@ -26,10 +26,10 @@ public class BetsApiClient {
 	/**
 	 * 예정 경기 조회
 	 */
-	public BetsEventResponse getUpcomingEvents(String externalSportId, String externalLeagueId, String day) {
+	public BetsEventResponse getUpcomingEvents(String apiSportId, String apiLeagueId, String day) {
 		String url = buildUrl("/v3/events/upcoming")
-			.queryParam("sport_id", externalSportId)
-			.queryParamIfPresent("league_id", java.util.Optional.ofNullable(externalLeagueId))
+			.queryParam("sport_id", apiSportId)
+			.queryParamIfPresent("league_id", java.util.Optional.ofNullable(apiLeagueId))
 			.queryParamIfPresent("day", java.util.Optional.ofNullable(day))
 			.build().toUriString();
 
@@ -40,10 +40,10 @@ public class BetsApiClient {
 	/**
 	 * 진행 중 경기 조회
 	 */
-	public BetsEventResponse getInplayEvents(String externalSportId, String externalLeagueId) {
+	public BetsEventResponse getInplayEvents(String apiSportId, String apiLeagueId) {
 		String url = buildUrl("/v3/events/inplay")
-			.queryParam("sport_id", externalSportId)
-			.queryParamIfPresent("league_id", java.util.Optional.ofNullable(externalLeagueId))
+			.queryParam("sport_id", apiSportId)
+			.queryParamIfPresent("league_id", java.util.Optional.ofNullable(apiLeagueId))
 			.build().toUriString();
 
 		log.debug("BetsAPI 호출: {}", maskToken(url));
@@ -53,10 +53,10 @@ public class BetsApiClient {
 	/**
 	 * 종료 경기 조회
 	 */
-	public BetsEventResponse getEndedEvents(String externalSportId, String externalLeagueId, String day) {
+	public BetsEventResponse getEndedEvents(String apiSportId, String apiLeagueId, String day) {
 		String url = buildUrl("/v3/events/ended")
-			.queryParam("sport_id", externalSportId)
-			.queryParamIfPresent("league_id", java.util.Optional.ofNullable(externalLeagueId))
+			.queryParam("sport_id", apiSportId)
+			.queryParamIfPresent("league_id", java.util.Optional.ofNullable(apiLeagueId))
 			.queryParamIfPresent("day", java.util.Optional.ofNullable(day))
 			.build().toUriString();
 
@@ -67,9 +67,9 @@ public class BetsApiClient {
 	/**
 	 * 리그 목록 조회
 	 */
-	public BetsLeagueResponse getLeagues(String externalSportId, int page) {
+	public BetsLeagueResponse getLeagues(String apiSportId, int page) {
 		String url = buildUrl("/v4/league")
-			.queryParam("sport_id", externalSportId)
+			.queryParam("sport_id", apiSportId)
 			.queryParam("page", page)
 			.build().toUriString();
 
@@ -80,9 +80,9 @@ public class BetsApiClient {
 	/**
 	 * 팀 목록 조회
 	 */
-	public BetsTeamResponse getTeams(String externalSportId, String maxId) {
+	public BetsTeamResponse getTeams(String apiSportId, String maxId) {
 		String url = buildUrl("/v3/team")
-			.queryParam("sport_id", externalSportId)
+			.queryParam("sport_id", apiSportId)
 			.queryParamIfPresent("max_id", java.util.Optional.ofNullable(maxId))
 			.build().toUriString();
 

--- a/src/main/java/com/scorenow/scorenow_api/global/config/RedisConfig.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/config/RedisConfig.java
@@ -2,6 +2,9 @@ package com.scorenow.scorenow_api.global.config;
 
 import java.time.Duration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -19,53 +22,62 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableCaching
 public class RedisConfig {
 
-	/**
-	 * RedisTemplate 설정
-	 * - Key: String (StringRedisSerializer)
-	 * - Value: JSON (GenericJackson2JsonRedisSerializer)
-	 */
-	@Bean
-	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
-		RedisTemplate<String, Object> template = new RedisTemplate<>();
-		template.setConnectionFactory(connectionFactory);
+    /**
+     * RedisTemplate 설정
+     * - Key: String (StringRedisSerializer)
+     * - Value: JSON (GenericJackson2JsonRedisSerializer)
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
 
-		// Key는 String으로 직렬화
-		template.setKeySerializer(new StringRedisSerializer());
-		template.setHashKeySerializer(new StringRedisSerializer());
+        // Key는 String으로 직렬화
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
 
-		// Value는 JSON으로 직렬화
-		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
-		template.setValueSerializer(serializer);
-		template.setHashValueSerializer(serializer);
+        // ObjectMapper 커스텀 설정 : java.time.* 패키지 타입 직렬화 에러 대응
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.activateDefaultTyping(
+                mapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+        );
 
-		return template;
-	}
+        // Value는 JSON으로 직렬화
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(mapper);
+        template.setValueSerializer(serializer);
+        template.setHashValueSerializer(serializer);
 
-	/**
-	 * CacheManager 설정
-	 * - TTL: 10분
-	 * - JSON: 직렬화
-	 */
-	@Bean
-	public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-			.entryTtl(Duration.ofMinutes(10)) // 기본 TTL 10분
-			.serializeKeysWith(
-				RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
-			)
-			.serializeValuesWith(
-				RedisSerializationContext.SerializationPair.fromSerializer(
-					new GenericJackson2JsonRedisSerializer()
-				)
-			);
+        return template;
+    }
 
-		return RedisCacheManager.builder(connectionFactory)
-			.cacheDefaults(config)
-			.build();
-	}
+    /**
+     * CacheManager 설정
+     * - TTL: 10분
+     * - JSON: 직렬화
+     */
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10)) // 기본 TTL 10분
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                )
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer()
+                        )
+                );
 
-	@Bean
-	public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
-		return new StringRedisTemplate(connectionFactory);
-	}
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
 }

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadServiceTest.java
@@ -1,0 +1,57 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import com.scorenow.scorenow_api.domain.match.dto.MatchCandidate;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import com.scorenow.scorenow_api.domain.match.repository.redis.InplayMatchRedisRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.NOT_STARTED;
+import static com.scorenow.scorenow_api.external.common.ApiProvider.BETS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class InplayMatchCandidateLoadServiceTest {
+
+    @InjectMocks
+    private InplayMatchCandidateLoadService service;
+
+    @Mock
+    private MatchRepository matchRepository;
+
+    @Mock
+    private InplayMatchRedisRepository inplayMatchRedisRepository;
+
+    @Test
+    void 시작_예정인_경기를_DB에서_조회하여_Redis에_캐싱한다() {
+        ZonedDateTime now = ZonedDateTime.of(2026, 1, 1, 13, 0, 0, 0, ZoneId.of("Asia/Seoul"));
+
+        // 1시간 이내 시작 예정 경기 2건 세팅
+        MatchCandidate candidate1 = new MatchCandidate(1L, 1L, BETS, "100", "1", LocalDateTime.of(2026, 1, 1, 13, 30));
+        MatchCandidate candidate2 = new MatchCandidate(2L, 1L, BETS, "101", "1", LocalDateTime.of(2026, 1, 1, 13, 45));
+        List<MatchCandidate> candidates = List.of(candidate1, candidate2);
+
+        // 1시간 이내 시작 예정인 경기 목록 조회 시 반환 값 세팅
+        given(matchRepository.findMatchesStartingWithin(NOT_STARTED, now.toLocalDateTime(), now.plusHours(1L).toLocalDateTime()))
+                .willReturn(candidates);
+
+        service.loadInplayCandidatesToCache(now.toLocalDateTime());
+
+        // MatchRepository.findMatchesStartingWithin 1회 호출되었음을 검증
+        then(matchRepository).should(times(1)).findMatchesStartingWithin(any(), any(), any());
+
+        // InplayMatchRedisRepository.addCandidate {candidates.size} 만큼 호출되었음을 검증
+        then(inplayMatchRedisRepository).should(times(candidates.size())).addCandidate(any(), any());
+    }
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchStatusUpdaterTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchStatusUpdaterTest.java
@@ -1,0 +1,63 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import com.scorenow.scorenow_api.domain.match.dto.MatchCandidate;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.IN_PLAY;
+import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.TO_BE_FIXED;
+import static com.scorenow.scorenow_api.external.common.ApiProvider.BETS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class InplayMatchStatusUpdaterTest {
+    @InjectMocks
+    private InplayMatchStatusUpdater service;
+
+    @Mock
+    private MatchRepository matchRepository;
+
+    @Test
+    void 진행_중인_경기와_유예기간_초과한_경기에_맞춰_일괄로_경기_상태_업데이트를_처리한다() {
+        MatchCandidate inplayCandidate1 = new MatchCandidate(1L, 1L, BETS, "100", "SOCCER", LocalDateTime.now());
+        MatchCandidate inplayCandidate2 = new MatchCandidate(2L, 1L, BETS, "101", "SOCCER", LocalDateTime.now());
+        MatchCandidate toBeFixedCandidate = new MatchCandidate(3L, 1L, BETS, "103", "SOCCER", LocalDateTime.now().minusMinutes(20));
+
+        List<MatchCandidate> inplayCandidates = List.of(inplayCandidate1, inplayCandidate2);
+        List<MatchCandidate> toBeFixedCandidates = List.of(toBeFixedCandidate);
+
+        service.updateMatchStatuses(inplayCandidates, toBeFixedCandidates);
+
+        List<Long> inplayCandidateIds = inplayCandidates.stream().map(MatchCandidate::getMatchId).toList();
+        List<Long> toBeFixedCandidateIds = toBeFixedCandidates.stream().map(MatchCandidate::getMatchId).toList();
+
+        // MatchRepository.updateStatusBulk(any(), IN_PLAY) 1회 호출 검증
+        then(matchRepository).should(times(1)).updateStatusBulk(eq(inplayCandidateIds), eq(IN_PLAY));
+        // MatchRepository.updateStatusBulk(any(), TO_BE_FIXED) 1회 호출 검증
+        then(matchRepository).should(times(1)).updateStatusBulk(eq(toBeFixedCandidateIds), eq(TO_BE_FIXED));
+    }
+
+    @Test
+    void 진행_중인_경기만_있고_유예기간_초과한_경기는_없는_경우_진행_중인_경기에_대해서만_상태_업데이트를_처리한다() {
+        MatchCandidate inplayCandidate = new MatchCandidate(1L, 1L, BETS, "100", "SOCCER", LocalDateTime.now());
+
+        service.updateMatchStatuses(List.of(inplayCandidate), Collections.emptyList());
+
+        // MatchRepository.updateStatusBulk(any(), IN_PLAY) 1회 호출 검증
+        then(matchRepository).should(times(1)).updateStatusBulk(any(), eq(IN_PLAY));
+        // MatchRepository.updateStatusBulk(any(), TO_BE_FIXED) 0회 호출 검증
+        then(matchRepository).should(times(0)).updateStatusBulk(any(), eq(TO_BE_FIXED));
+    }
+
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncServiceTest.java
@@ -1,0 +1,85 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import com.scorenow.scorenow_api.domain.match.dto.MatchCandidate;
+import com.scorenow.scorenow_api.domain.match.repository.redis.InplayMatchRedisRepository;
+import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsEventResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.scorenow.scorenow_api.external.common.ApiProvider.BETS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class InplayMatchSyncServiceTest {
+
+    @InjectMocks
+    private InplayMatchSyncService service;
+
+    @Mock
+    private BetsApiClient betsApiClient;
+
+    @Mock
+    private InplayMatchStatusUpdater inplayMatchStatusUpdater;
+
+    @Mock
+    private InplayMatchRedisRepository inplayMatchRedisRepository;
+
+    @Test
+    void API_응답을_대조하여_진행_중인_경기와_유예기간_초과_경기를_정상적으로_분류하고_반영한다() {
+        ZonedDateTime now = ZonedDateTime.of(2026, 1, 1, 13, 30, 0, 0, ZoneId.of("Asia/Seoul"));
+
+        // 동기화 대상 조회 결과 세팅 현재 시작 예정 경기 세팅 (축구 2건 + 야구 1건 + 농구 1건) / 농구의 경우 유예기간 초과 경기
+        MatchCandidate soccerCandidate1 = new MatchCandidate(1L, 1L, BETS, "100", "SOCCER", now.toLocalDateTime());
+        MatchCandidate soccerCandidate2 = new MatchCandidate(2L, 1L, BETS, "101", "SOCCER", now.toLocalDateTime());
+        MatchCandidate baseballCandidate1 = new MatchCandidate(3L, 2L, BETS, "200", "BASEBALL", now.toLocalDateTime());
+        MatchCandidate basketballCandidate1 = new MatchCandidate(4L, 3L, BETS, "300", "BASKETBALL", now.minusMinutes(20).toLocalDateTime());
+
+        given(inplayMatchRedisRepository.findCandidatesToSync(now)).willReturn(List.of(soccerCandidate1, soccerCandidate2, baseballCandidate1, basketballCandidate1));
+
+        // INPLAY API 응답값 세팅
+        BetsEventResponse inplaySoccer = getBetsEventResponse(List.of("100", "101"));
+        BetsEventResponse inplayBaseball = getBetsEventResponse(List.of("200"));
+        BetsEventResponse inplayBasketball = getBetsEventResponse(List.of("300"));
+
+        given(betsApiClient.getInplayEvents("SOCCER", null)).willReturn(inplaySoccer);
+        given(betsApiClient.getInplayEvents("BASEBALL", null)).willReturn(inplayBaseball);
+        given(betsApiClient.getInplayEvents("BASKETBALL", null)).willReturn(inplayBasketball);
+
+        service.syncInplayMatches(now.toLocalDateTime());
+
+        // API 3회 호출 (축구 1회, 야구 1회, 농구 1회)
+        then(betsApiClient).should(times(3)).getInplayEvents(any(), any());
+
+        // InplayMatchStatusUpdater.updateMatchStatuses 1회 호출 검증
+        then(inplayMatchStatusUpdater).should(times(1)).updateMatchStatuses(any(), any());
+
+        // InplayMatchRedisRepository.removeCandiates 2회 호출 검증
+        then(inplayMatchRedisRepository).should(times(2)).removeCandidates(any());
+    }
+
+    private BetsEventResponse getBetsEventResponse(List<String> apiMatchIds) {
+        List<BetsEventResponse.Event> events = new ArrayList<>();
+        for (String apiMatchId : apiMatchIds) {
+            BetsEventResponse.Event event = new BetsEventResponse.Event();
+            event.setId(apiMatchId);
+
+            events.add(event);
+        }
+
+        BetsEventResponse betsEventResponse = new BetsEventResponse();
+        betsEventResponse.setResults(events);
+        return betsEventResponse;
+    }
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static com.scorenow.scorenow_api.external.common.ApiProvider.BETS;
@@ -51,7 +52,7 @@ class InplayMatchSyncServiceTest {
         // INPLAY API 응답값 세팅
         BetsEventResponse inplaySoccer = getBetsEventResponse(List.of("100", "101"));
         BetsEventResponse inplayBaseball = getBetsEventResponse(List.of("200"));
-        BetsEventResponse inplayBasketball = getBetsEventResponse(List.of("300"));
+        BetsEventResponse inplayBasketball = getBetsEventResponse(Collections.emptyList());  // 유예기간 초과의 경우
 
         given(betsApiClient.getInplayEvents("SOCCER", null)).willReturn(inplaySoccer);
         given(betsApiClient.getInplayEvents("BASEBALL", null)).willReturn(inplayBaseball);
@@ -59,8 +60,10 @@ class InplayMatchSyncServiceTest {
 
         service.syncInplayMatches(now.toLocalDateTime());
 
-        // API 3회 호출 (축구 1회, 야구 1회, 농구 1회)
-        then(betsApiClient).should(times(3)).getInplayEvents(any(), any());
+        // API 총 3회 호출 (축구 1회, 야구 1회, 농구 1회)
+        then(betsApiClient).should(times(1)).getInplayEvents("SOCCER", null);
+        then(betsApiClient).should(times(1)).getInplayEvents("BASEBALL", null);
+        then(betsApiClient).should(times(1)).getInplayEvents("BASKETBALL", null);
 
         // InplayMatchStatusUpdater.updateMatchStatuses 1회 호출 검증
         then(inplayMatchStatusUpdater).should(times(1)).updateMatchStatuses(any(), any());


### PR DESCRIPTION
## #️⃣ Issue Number
> 이슈번호: #67
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
NOT_STARTED 상태의 경기를 IN_PLAY 로 전환하는 기능 추가
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
NOT_STARTED 상태의 경기를 경기 시간에 맞춰 IN_PLAY 로 전환하는 기능은 다음과 같은 단계로 처리 됩니다.
1. 30분마다 스케줄링을 통해 1시간 이내에 시작하는 경기를 Redis ZSet 에 저장
2. 1분마다 스케줄링을 통해 Redis ZSet 에 저장된 데이터 중 현재 시작된 경기로 보이는 경기들을 추출하고,
     외부 API 의 데이터와 비교하여 실제로 시작된 경기라면 상태를 IN_PLAY 로 변경

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
