### PR TITLE
feat: View API 중복 호출 방지를 위한 통합

### DIFF
--- a/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchDetailController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchDetailController.java
@@ -13,9 +13,6 @@ public class MatchDetailController {
 
     private final MatchDetailService matchDetailService;
 
-    /**
-     * TODO: MatchDetailDocument 에 점수 정보가 안보임
-     */
     @PatchMapping("/{matchId}/detail")
     public ApiResponse<Long> updateMatchDetail(
             @PathVariable Long matchId,

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/MatchDetailRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/MatchDetailRepository.java
@@ -10,4 +10,6 @@ public interface MatchDetailRepository {
     MatchDetailDocument save(MatchDetailDocument detail);
 
     long updateCurrentCommentary(Long matchId, String content, String commentaryId);
+
+    void upsertMatchDetail(MatchDetailDocument matchDetailDocument);
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
@@ -52,6 +52,7 @@ public interface MatchRepository extends JpaRepository<Match, Long>, MatchReposi
             	from Match m
             	where m.provider = :provider
             	  and m.apiMatchId = :apiMatchId
+                  and m.isManual = false
             """)
     Optional<Match> findByExternalInfo(
             @Param("provider") ApiProvider provider,
@@ -79,4 +80,6 @@ public interface MatchRepository extends JpaRepository<Match, Long>, MatchReposi
     @Modifying(clearAutomatically = true)
     @Query("update Match m set m.statusCode = :status, m.updatedAt = CURRENT_TIMESTAMP where m.id IN :matchIds")
     void updateStatusBulk(List<Long> matchIds, MatchStatus status);
+
+    List<Match> findByStatusCodeAndIsManualFalse(MatchStatus matchStatus);
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/mongo/MatchDetailRepositoryImpl.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/mongo/MatchDetailRepositoryImpl.java
@@ -3,18 +3,25 @@ package com.scorenow.scorenow_api.domain.match.repository.mongo;
 import com.scorenow.scorenow_api.domain.match.document.MatchDetailDocument;
 import com.scorenow.scorenow_api.domain.match.repository.MatchDetailRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+
+import static com.scorenow.scorenow_api.domain.match.document.MatchDetailDocument.*;
 
 @Repository
 @RequiredArgsConstructor
 public class MatchDetailRepositoryImpl implements MatchDetailRepository {
     private final MatchDetailMongoRepository mongoRepository;
+    private final MongoTemplate mongoTemplate;
 
     @Override
-    public MatchDetailDocument save(MatchDetailDocument matchDetail) {
-        return mongoRepository.save(matchDetail);
+    public MatchDetailDocument save(MatchDetailDocument matchDetailDocument) {
+        return mongoRepository.save(matchDetailDocument);
     }
 
     @Override
@@ -25,5 +32,32 @@ public class MatchDetailRepositoryImpl implements MatchDetailRepository {
     @Override
     public long updateCurrentCommentary(Long matchId, String content, String commentaryId) {
         return mongoRepository.updateCurrentCommentary(matchId, content, commentaryId);
+    }
+
+    @Override
+    public void upsertMatchDetail(MatchDetailDocument matchDetailDocument) {
+        Query query = new Query(Criteria.where("_id").is(matchDetailDocument.getId()));
+        Update update = new Update();
+
+        update.set("homeScore", matchDetailDocument.getHomeScore());
+        update.set("homeStats", matchDetailDocument.getHomeStats());
+        update.set("awayScore", matchDetailDocument.getAwayScore());
+        update.set("awayStats", matchDetailDocument.getAwayStats());
+
+        ExtraTime extraTime = matchDetailDocument.getExtraTime();
+        if (extraTime != null) {
+            Integer firstHalf = extraTime.getFirstHalf();
+            Integer secondHalf = extraTime.getSecondHalf();
+
+            if (firstHalf != null) {
+                update.set("extraTime.firstHalf", firstHalf);
+            }
+
+            if (secondHalf != null) {
+                update.set("extraTime.secondHalf", secondHalf);
+            }
+        }
+
+        mongoTemplate.upsert(query, update, MatchDetailDocument.class);
     }
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchDetailScheduler.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchDetailScheduler.java
@@ -1,15 +1,9 @@
 package com.scorenow.scorenow_api.domain.match.scheduler;
 
-import java.util.List;
-
+import com.scorenow.scorenow_api.domain.match.service.MatchDetailSyncService;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import com.scorenow.scorenow_api.domain.match.entity.Match;
-import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
-import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
-import com.scorenow.scorenow_api.domain.match.service.MatchDetailService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,18 +14,20 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MatchDetailScheduler {
 
-	private final MatchRepository matchRepository; // MySQL
-	private final MatchDetailService matchDetailService;
+    private final MatchDetailSyncService matchDetailSyncService;
 
-	@Scheduled(fixedDelay = 50000)
-	public void syncInplayDetails() {
-		log.info(">>>>>> 스케줄러 실행 확인 <<<<<<");
-		List<Match> inplayMatches = matchRepository.findByStatusCode(MatchStatus.IN_PLAY);
-		log.info("조회된 In-play 경기 수: {}", inplayMatches.size());
+    /**
+     * 작업 내용 : 현재 진행중인 경기의 세부 정보를 동기화 한다. (세부 정보 : 경기 중 발생한 이벤트 기반으로 수치화된 스텟 정보들)
+     * 작업 주기 : 1분 마다
+     */
+    @Scheduled(fixedDelay = 60000)  // TODO: 작업 주기는 동적으로 관리될 필요가 있을 듯 하고, 추가적으로 API 리밋도 같이 고려하는 주기로 설정해야 한다.
+    public void syncInplayMatchDetails() {
+        log.info("📅 INPLAY 경기 세부 정보 동기화 시작");
 
-        for (Match match : inplayMatches) {
-            log.info("상세 업데이트 시작 - 경기 ID: {}", match.getId());
-            matchDetailService.updateInplayMatchDetail(match.getId(), match.getApiMatchId());
+        try {
+            matchDetailSyncService.syncInplayMatchDetails();
+        } catch (Exception e) {
+            log.error("INPLAY 경기 세부 정보 동기화 작업 중 예외 발생 ❌", e);
         }
     }
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailService.java
@@ -57,7 +57,7 @@ public class MatchDetailService {
 
         // 경기 정보 반영
         MatchDetailDocument detail = matchDetail.toDocument(match.getId());
-        matchDetailRepository.save(detail);
+        matchDetailRepository.upsertMatchDetail(detail);
 
         log.info("✅ 경기 상세 데이터(MySQL & MongoDB) 동기화 완료 matchId:{}, apiMatchId:{}", match.getId(), apiMatchId);
     }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailService.java
@@ -8,8 +8,9 @@ import com.scorenow.scorenow_api.domain.match.repository.MatchDetailRepository;
 import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
 import com.scorenow.scorenow_api.domain.stadium.entity.Stadium;
 import com.scorenow.scorenow_api.domain.stadium.service.StadiumCacheService;
-import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
-import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse.StadiumData;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse.ViewResult;
+import com.scorenow.scorenow_api.external.common.ApiProvider;
 import com.scorenow.scorenow_api.global.exception.BusinessException;
 import com.scorenow.scorenow_api.global.exception.ErrorCode;
 
@@ -18,39 +19,36 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.NOT_STARTED;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class MatchDetailService {
+
     private final StadiumCacheService stadiumCacheService;
     private final MatchRepository matchRepository;
     private final MatchDetailRepository matchDetailRepository;
-    private final BetsApiClient betsApiClient;
 
     @Transactional
-    public void updateInplayMatchDetail(Long matchId, String apiMatchId) {
-        BetsViewResponse response = betsApiClient.getEventView(apiMatchId);
+    public void updateInplayMatchDetail(ApiProvider provider, ViewResult matchDetail) {
+        String apiMatchId = matchDetail.getId();
 
-        if (response == null || !response.hasResult()) {
-            log.warn("❌ 실패: ID {}에 대한 API 응답 데이터가 없습니다.", apiMatchId);
-            return;
+        Match match = matchRepository.findByExternalInfo(provider, apiMatchId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MATCH_NOT_FOUND));
+
+        MatchStatus matchStatus = MatchStatus.fromCode(matchDetail.getTimeStatus());
+        if (matchStatus != NOT_STARTED) {
+            match.updateStatus(matchStatus);
         }
-
-        BetsViewResponse.ViewResult apiResult = response.getResults().get(0);
-
-        // Match 영속화를 위한 조회
-        Match match = matchRepository.findById(matchId).orElseThrow(() -> new BusinessException(ErrorCode.MATCH_NOT_FOUND));
-
-        // 홈-어웨이 스코어 변경
-        match.updateHomeScore(apiResult.getHomeScore());
-        match.updateAwayScore(apiResult.getAwayScore());
+        match.updateHomeScore(matchDetail.getHomeScore());
+        match.updateAwayScore(matchDetail.getAwayScore());
 
         // 경기장 정보 생성 및 변경 (로컬 캐시 활용 + 더티체킹)
-        BetsViewResponse.StadiumData stadiumData = apiResult.getExtra().getStadiumData();
-        log.info("stadiumData: {}", stadiumData);
+        StadiumData stadiumData = matchDetail.getExtra().getStadiumData();
         if (stadiumData != null) {
-            Stadium stadium = stadiumCacheService.getOrCreateStadium(response.getProvider(), apiResult.getSportId(), stadiumData.getId(), stadiumData.getName(), stadiumData.getCity());
-            log.info("stadium = {}", stadium);
+            Stadium stadium = stadiumCacheService.getOrCreateStadium(provider, matchDetail.getSportId(), stadiumData.getId(), stadiumData.getName(), stadiumData.getCity());
+
             // 경기 정보에 경기장 정보가 할당되어 있지 않은 경우에만 할당
             if (match.isStadiumEmpty()) {
                 match.updateStadiumId(stadium.getId());
@@ -58,10 +56,10 @@ public class MatchDetailService {
         }
 
         // 경기 정보 반영
-        MatchDetailDocument detail = response.toDocument(matchId, apiResult.getHomeScore(), apiResult.getAwayScore());
+        MatchDetailDocument detail = matchDetail.toDocument(match.getId());
         matchDetailRepository.save(detail);
 
-        log.info("✅ 성공: {} 경기 상세 데이터(MySQL & MongoDB) 동기화 완료", matchId);
+        log.info("✅ 경기 상세 데이터(MySQL & MongoDB) 동기화 완료 matchId:{}, apiMatchId:{}", match.getId(), apiMatchId);
     }
 
     /**
@@ -93,7 +91,7 @@ public class MatchDetailService {
 
         detail.updateFrom(request);
 
-        log.info("📊 MongoDB 상세 지표 수동 수정 완료: {}", matchId);
+        log.info("📊 MatchDetailDocument 수동 수정 완료: {}", matchId);
         return matchDetailRepository.save(detail).getId();
     }
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncService.java
@@ -1,0 +1,130 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import com.scorenow.scorenow_api.domain.match.document.MatchLineupDocument;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.redis.InplayRedisService;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import com.scorenow.scorenow_api.domain.match.repository.mongo.MatchLineupRepository;
+import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse.ViewResult;
+import com.scorenow.scorenow_api.external.common.ApiProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.IN_PLAY;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MatchDetailSyncService {
+
+    private static final int BATCH_SIZE = 10;
+
+    private final BetsApiClient betsApiClient;
+
+    private final MatchRepository matchRepository;
+    private final MatchLineupRepository matchLineupRepository;
+
+    private final MatchDetailService matchDetailService;
+    private final InplayRedisService inplayRedisService;
+    private final MatchLineupGoalsService matchLineupGoalsService;
+
+    public void syncInplayMatchDetails() {
+        // 1. Inplay 상태인 경기들을 조회한다. (단, 수동 경기의 경우 제외)
+        List<Match> inplayMatches = matchRepository.findByStatusCodeAndIsManualFalse(IN_PLAY);
+
+        if (inplayMatches.isEmpty()) {
+            log.info("현재 INPLAY 상태의 경기가 없습니다.");
+            return;
+        }
+
+        // 2. API 호출을 위한 apiMatchId 로 변환한다.
+        List<String> apiMatchIds = inplayMatches.stream()
+                .map(Match::getApiMatchId)
+                .toList();
+
+        // 3. Event View API 는 한번에 최대 10개의 경기까지 호출할 수 있다. 이를 위한 형식으로 변경한다.
+        List<String> eventIdBatches = createEventIdBatches(apiMatchIds);
+
+        // 4. Event View API 를 호출하고, 응답값을 Map<apiMatchId, MatchDetail> 형식으로 변경한다.
+        List<BetsViewResponse> betsViewResponses = new ArrayList<>();
+        for (String eventIdBatch : eventIdBatches) {
+            try {
+                log.info("📡[Event View API 호출] eventId : {}", eventIdBatch);
+                betsViewResponses.add(betsApiClient.getEventView(eventIdBatch));
+            } catch (Exception e) {
+                log.warn("❌[Event View API 호출 실패] eventId : {}", eventIdBatch, e);
+            }
+        }
+
+        Map<String, ViewResult> matchDetails = betsViewResponses.stream()
+                .flatMap(viewResponse -> viewResponse.getResults().stream())
+                .collect(Collectors.toMap(ViewResult::getId, viewResult -> viewResult));
+
+        // 5. Inplay 인 경기 정보를 기반으로 MatchLineupDocument 를 조회한다. (라인업-골 정보 업데이트를 위하여 조회)
+        List<Long> matchIds = inplayMatches.stream().map(Match::getId).toList();
+
+        Map<Long, MatchLineupDocument> matchLineupDocuments = matchLineupRepository.findByIdIn(matchIds).stream()
+                .collect(Collectors.toMap(MatchLineupDocument::getId, matchLineupDocument -> matchLineupDocument));
+
+        // 6. 각 Inplay 경기의 세부 정보 및 라인업-골 정보를 업데이트 한다.
+        for (Match inplayMatch : inplayMatches) {
+            Long matchId = inplayMatch.getId();
+            Long sportId = inplayMatch.getSportId();
+            String apiMatchId = inplayMatch.getApiMatchId();
+
+            ViewResult matchDetail = matchDetails.get(apiMatchId);
+            if (matchDetail == null) {
+                log.info("경기에 대한 세부 정보가 존재하지 않습니다 - matchId:{}, apiMatchId:{}", matchId, apiMatchId);
+                continue;
+            }
+
+            try {
+                // 경기 세부 정보 업데이트
+                matchDetailService.updateInplayMatchDetail(ApiProvider.BETS, matchDetail);
+
+                // Lineup 이 없는 경우, MatchLineupSyncScheduler 가 처리할 수 있게 레디스 큐에 삽입해준다.
+                if (requiresLineupInit(matchDetail.hasLineup(), matchLineupDocuments.containsKey(matchId))) {
+                    boolean isEnqueued = inplayRedisService.markSeenAndEnqueue(String.valueOf(matchId), String.valueOf(sportId));
+                    log.debug("LineupQueue 에 삽입 {} - matchId:{}", isEnqueued ? "성공" : "실패", matchId);
+                    continue;
+                }
+
+                // 라인업-골 정보 업데이트
+                MatchLineupDocument matchLineupDocument = matchLineupDocuments.get(matchId);
+                matchLineupGoalsService.updateLineupGoals(matchLineupDocument, matchDetail);
+            } catch (Exception e) {
+                log.error("❌ INPLAY 경기 세부 정보 업데이트 처리 중 실패 - matchId: {}", inplayMatch.getId(), e);
+            }
+        }
+    }
+
+    private boolean requiresLineupInit(boolean isLineupProvided, boolean hasLineupAlready) {
+        return isLineupProvided && !hasLineupAlready;
+    }
+
+    /**
+     * 로직은 아래와 같다.
+     * apiMatchIds : ["100","101","102","103","104","105","106","107","108","109","110"]
+     * eventIdBatches :["100,101,102,103,104,105,106,107,108,109","110"]
+     */
+    private List<String> createEventIdBatches(List<String> ids) {
+        List<String> batches = new ArrayList<>();
+
+        for (int from = 0; from < ids.size(); from += BATCH_SIZE) {
+            int to = Math.min(from + BATCH_SIZE, ids.size());
+
+            List<String> batch = ids.subList(from, to);
+            batches.add(String.join(",", batch));
+        }
+
+        return batches;
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncService.java
@@ -66,13 +66,19 @@ public class MatchDetailSyncService {
 
         Map<String, ViewResult> matchDetails = betsViewResponses.stream()
                 .flatMap(viewResponse -> viewResponse.getResults().stream())
-                .collect(Collectors.toMap(ViewResult::getId, viewResult -> viewResult));
+                .collect(Collectors.toMap(
+                        ViewResult::getId,
+                        viewResult -> viewResult,
+                        (existing, replacement) -> existing));
 
         // 5. Inplay 인 경기 정보를 기반으로 MatchLineupDocument 를 조회한다. (라인업-골 정보 업데이트를 위하여 조회)
         List<Long> matchIds = inplayMatches.stream().map(Match::getId).toList();
 
         Map<Long, MatchLineupDocument> matchLineupDocuments = matchLineupRepository.findByIdIn(matchIds).stream()
-                .collect(Collectors.toMap(MatchLineupDocument::getId, matchLineupDocument -> matchLineupDocument));
+                .collect(Collectors.toMap(
+                        MatchLineupDocument::getId,
+                        matchLineupDocument -> matchLineupDocument,
+                        (existing, replacement) -> existing));
 
         // 6. 각 Inplay 경기의 세부 정보 및 라인업-골 정보를 업데이트 한다.
         for (Match inplayMatch : inplayMatches) {
@@ -87,19 +93,19 @@ public class MatchDetailSyncService {
             }
 
             try {
-                // 경기 세부 정보 업데이트
-                matchDetailService.updateInplayMatchDetail(ApiProvider.BETS, matchDetail);
+                matchDetailService.updateInplayMatchDetail(ApiProvider.BETS, matchDetail);  // 경기 세부 정보 업데이트
 
-                // Lineup 이 없는 경우, MatchLineupSyncScheduler 가 처리할 수 있게 레디스 큐에 삽입해준다.
-                if (requiresLineupInit(matchDetail.hasLineup(), matchLineupDocuments.containsKey(matchId))) {
-                    boolean isEnqueued = inplayRedisService.markSeenAndEnqueue(String.valueOf(matchId), String.valueOf(sportId));
-                    log.debug("LineupQueue 에 삽입 {} - matchId:{}", isEnqueued ? "성공" : "실패", matchId);
-                    continue;
+                if (matchDetail.hasLineup()) {
+                    if (!matchLineupDocuments.containsKey(matchId)) {   // Lineup 이 없는 경우, MatchLineupSyncScheduler 가 처리할 수 있게 레디스 큐에 삽입해준다.
+                        boolean isEnqueued = inplayRedisService.markSeenAndEnqueue(String.valueOf(matchId), String.valueOf(sportId));
+                        log.debug("LineupQueue 에 삽입 {} - matchId:{}", isEnqueued ? "성공" : "실패", matchId);
+                        continue;
+                    }
+
+                    // 라인업-골 정보 업데이트
+                    MatchLineupDocument matchLineupDocument = matchLineupDocuments.get(matchId);
+                    matchLineupGoalsService.updateLineupGoals(matchLineupDocument, matchDetail);
                 }
-
-                // 라인업-골 정보 업데이트
-                MatchLineupDocument matchLineupDocument = matchLineupDocuments.get(matchId);
-                matchLineupGoalsService.updateLineupGoals(matchLineupDocument, matchDetail);
             } catch (Exception e) {
                 log.error("❌ INPLAY 경기 세부 정보 업데이트 처리 중 실패 - matchId: {}", inplayMatch.getId(), e);
             }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncService.java
@@ -98,7 +98,7 @@ public class MatchDetailSyncService {
                 if (matchDetail.hasLineup()) {
                     if (!matchLineupDocuments.containsKey(matchId)) {   // Lineup 이 없는 경우, MatchLineupSyncScheduler 가 처리할 수 있게 레디스 큐에 삽입해준다.
                         boolean isEnqueued = inplayRedisService.markSeenAndEnqueue(String.valueOf(matchId), String.valueOf(sportId));
-                        log.debug("LineupQueue 에 삽입 {} - matchId:{}", isEnqueued ? "성공" : "실패", matchId);
+                        log.info("LineupQueue 에 삽입 {} - matchId:{}", isEnqueued ? "성공" : "실패", matchId);
                         continue;
                     }
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncService.java
@@ -112,10 +112,6 @@ public class MatchDetailSyncService {
         }
     }
 
-    private boolean requiresLineupInit(boolean isLineupProvided, boolean hasLineupAlready) {
-        return isLineupProvided && !hasLineupAlready;
-    }
-
     /**
      * 로직은 아래와 같다.
      * apiMatchIds : ["100","101","102","103","104","105","106","107","108","109","110"]

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncService.java
@@ -65,7 +65,9 @@ public class MatchDetailSyncService {
         }
 
         Map<String, ViewResult> matchDetails = betsViewResponses.stream()
+                .filter(viewResponse -> viewResponse != null && viewResponse.hasResults())
                 .flatMap(viewResponse -> viewResponse.getResults().stream())
+                .filter(viewResult -> viewResult != null && viewResult.getId() != null)
                 .collect(Collectors.toMap(
                         ViewResult::getId,
                         viewResult -> viewResult,
@@ -96,7 +98,8 @@ public class MatchDetailSyncService {
                 matchDetailService.updateInplayMatchDetail(ApiProvider.BETS, matchDetail);  // 경기 세부 정보 업데이트
 
                 if (matchDetail.hasLineup()) {
-                    if (!matchLineupDocuments.containsKey(matchId)) {   // Lineup 이 없는 경우, MatchLineupSyncScheduler 가 처리할 수 있게 레디스 큐에 삽입해준다.
+                    // Lineup 이 없는 경우, MatchLineupSyncScheduler 가 처리할 수 있게 레디스 큐에 삽입해준다.
+                    if (!matchLineupDocuments.containsKey(matchId)) {
                         boolean isEnqueued = inplayRedisService.markSeenAndEnqueue(String.valueOf(matchId), String.valueOf(sportId));
                         log.info("LineupQueue 에 삽입 {} - matchId:{}", isEnqueued ? "성공" : "실패", matchId);
                         continue;

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupGoalsService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupGoalsService.java
@@ -109,7 +109,7 @@ public class MatchLineupGoalsService {
 		List<BetsViewResponse.EventText> events = matchDetail.getEvents();
 
 		if (events == null || events.isEmpty()) {
-			log.debug("⏭[GOALS] events empty apiMatchId={}", matchDetail.getId());
+			log.info("⏭[GOALS] events empty apiMatchId={}", matchDetail.getId());
 			return;
 		}
 
@@ -121,9 +121,9 @@ public class MatchLineupGoalsService {
 
 		if (changed) {
 			matchLineupRepo.save(matchLineupDocument);
-			log.debug("✅[GOALS] 반영 완료 matchId={}, goalPlayers={}", matchLineupDocument.getId(), goalCounts.size());
+			log.info("✅[GOALS] 반영 완료 matchId={}, goalPlayers={}", matchLineupDocument.getId(), goalCounts.size());
 		} else {
-			log.debug("⏭[GOALS] 변경 없음 matchId={}", matchLineupDocument.getId());
+			log.info("⏭[GOALS] 변경 없음 matchId={}", matchLineupDocument.getId());
 		}
 	}
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupGoalsService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchLineupGoalsService.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse.ViewResult;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -100,6 +101,29 @@ public class MatchLineupGoalsService {
 		} catch (Exception e) {
 			log.warn("⚠[GOALS] 처리 중 예외 matchId={}, sportId={}, reason={}",
 				matchId, sportId, e.toString());
+		}
+	}
+
+	@Transactional
+	public void updateLineupGoals(MatchLineupDocument matchLineupDocument, ViewResult matchDetail) {
+		List<BetsViewResponse.EventText> events = matchDetail.getEvents();
+
+		if (events == null || events.isEmpty()) {
+			log.debug("⏭[GOALS] events empty apiMatchId={}", matchDetail.getId());
+			return;
+		}
+
+		Map<String, Integer> goalCounts = buildGoalCounts(events);
+
+		boolean changed = false;
+		changed |= applyGoalCountsToSide(matchLineupDocument.getHome(), goalCounts);
+		changed |= applyGoalCountsToSide(matchLineupDocument.getAway(), goalCounts);
+
+		if (changed) {
+			matchLineupRepo.save(matchLineupDocument);
+			log.debug("✅[GOALS] 반영 완료 matchId={}, goalPlayers={}", matchLineupDocument.getId(), goalCounts.size());
+		} else {
+			log.debug("⏭[GOALS] 변경 없음 matchId={}", matchLineupDocument.getId());
 		}
 	}
 

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/BetsApiClient.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/BetsApiClient.java
@@ -92,6 +92,7 @@ public class BetsApiClient {
 
 	/**
 	 * 경기 상세 정보 조회
+	 * 다건 조회 가능 (event_id=11915004,11914547,11914527,11914156)
 	 */
 	public BetsViewResponse getEventView(String eventId) {
 		String url = buildUrl("/v1/event/view")

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsViewResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsViewResponse.java
@@ -19,18 +19,6 @@ public class BetsViewResponse {
         return results != null && !results.isEmpty();
     }
 
-    public MatchDetailDocument toDocument(Long matchId, Integer homeScore, Integer awayScore) {
-        ViewResult result = results.get(0);
-        return MatchDetailDocument.builder()
-                .id(matchId)
-                .homeScore(homeScore)
-                .homeStats(result.toMatchStats(0))
-                .awayScore(awayScore)
-                .awayStats(result.toMatchStats(1))
-                .extraTime(result.toExtraTime())   // 추가시간
-                .build();
-    }
-
     @Data
     public static class ViewResult {
         private String id;      // 경기 고유 ID
@@ -71,8 +59,8 @@ public class BetsViewResponse {
             return MatchStats.builder()
                     .yellowCards(parse(stats.yellowCards, idx))
                     .redCards(parse(stats.redCards, idx))
-                    .shots(parse(stats.shots, idx))
-                    .shotsOnTarget(parse(stats.shotsOnTarget, idx))
+                    .shots(parse(stats.offTarget, idx))
+                    .shotsOnTarget(parse(stats.onTarget, idx))
                     .possession(parse(stats.possession, idx))
                     .offsides(parse(stats.offsides, idx))
                     .fouls(parse(stats.fouls, idx))
@@ -82,22 +70,30 @@ public class BetsViewResponse {
         }
 
         public MatchDetailDocument.ExtraTime toExtraTime() {
-            if (this.timer == null)
-                return defaultExtraTime();
+            // timer 값이 아예 안내려오는 경우 (경기 시작 전, 경기 종료)
+            if (this.timer == null) {
+                return null;
+            }
 
             return MatchDetailDocument.ExtraTime.builder()
-                    .firstHalf(this.timer.getTa() != null ? this.timer.getTa() : 0)
-                    .secondHalf(0)
+                    .firstHalf(getFirstHalfExtraTime())
+                    .secondHalf(getSecondHalfExtraTime())
                     .overTime(0)
                     .build();
         }
 
-        private MatchDetailDocument.ExtraTime defaultExtraTime() {
-            return MatchDetailDocument.ExtraTime.builder()
-                    .firstHalf(0)
-                    .secondHalf(0)
-                    .overTime(0)
-                    .build();
+        private Integer getFirstHalfExtraTime() {
+            if (timer.isFirstHalf()) {
+                return timer.ta != null ? timer.ta : null;
+            }
+            return null;
+        }
+
+        private Integer getSecondHalfExtraTime() {
+            if (timer.isSecondHalf()) {
+                return timer.ta != null ? timer.ta : null;
+            }
+            return null;
         }
 
         private Integer parse(List<String> list, int i) {
@@ -139,14 +135,14 @@ public class BetsViewResponse {
 
     @Data
     public static class Stats {
-        @JsonProperty("yellow_cards")
+        @JsonProperty("yellowcards")
         private List<String> yellowCards;
-        @JsonProperty("red_cards")
+        @JsonProperty("redcards")
         private List<String> redCards;
-        @JsonProperty("shott_total")
-        private List<String> shots;
-        @JsonProperty("shott_on_target")
-        private List<String> shotsOnTarget;
+        @JsonProperty("off_target")
+        private List<String> offTarget;
+        @JsonProperty("on_target")
+        private List<String> onTarget;
         @JsonProperty("possession_rt")
         private List<String> possession;
         @JsonProperty("offsides")
@@ -155,7 +151,7 @@ public class BetsViewResponse {
         private List<String> fouls;
         @JsonProperty("corners")
         private List<String> corners;
-        @JsonProperty("free_kicks")
+        @JsonProperty("freekicks")
         private List<String> freeKicks;
     }
 
@@ -165,6 +161,15 @@ public class BetsViewResponse {
         private Integer ts;     // 경과 초
         private String tt;      // 타이머 상태 (0:정지,1:진행)
         private Integer ta;     // 추가시간
+        private Integer md;     // 전후반 구분 (0:전반,1:후반)
+
+        public boolean isFirstHalf() {
+            return this.md == 0;
+        }
+
+        public boolean isSecondHalf() {
+            return this.md == 1;
+        }
     }
 
     @Data

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsViewResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsViewResponse.java
@@ -164,10 +164,12 @@ public class BetsViewResponse {
         private Integer md;     // 전후반 구분 (0:전반,1:후반)
 
         public boolean isFirstHalf() {
+            if (this.md == null) return false;
             return this.md == 0;
         }
 
         public boolean isSecondHalf() {
+            if (this.md == null) return false;
             return this.md == 1;
         }
     }

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsViewResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsViewResponse.java
@@ -11,155 +11,178 @@ import lombok.Data;
 
 @Data
 public class BetsViewResponse {
-	private final ApiProvider provider = ApiProvider.BETS;
+    private final ApiProvider provider = ApiProvider.BETS;
 
-	private List<ViewResult> results;
+    private List<ViewResult> results;
 
-	public boolean hasResult() {
-		return results != null && !results.isEmpty();
-	}
+    public boolean hasResult() {
+        return results != null && !results.isEmpty();
+    }
 
-	public MatchDetailDocument toDocument(Long matchId, Integer homeScore, Integer awayScore) {
-		ViewResult result = results.get(0);
-		return MatchDetailDocument.builder()
-			.id(matchId)
-			.homeStats(result.toMatchStats(0))
-			.awayStats(result.toMatchStats(1))
-			.extraTime(result.toExtraTime())   // 추가시간
-			.build();
-	}
+    public MatchDetailDocument toDocument(Long matchId, Integer homeScore, Integer awayScore) {
+        ViewResult result = results.get(0);
+        return MatchDetailDocument.builder()
+                .id(matchId)
+                .homeScore(homeScore)
+                .homeStats(result.toMatchStats(0))
+                .awayScore(awayScore)
+                .awayStats(result.toMatchStats(1))
+                .extraTime(result.toExtraTime())   // 추가시간
+                .build();
+    }
 
-	@Data
-	public static class ViewResult {
-		private String id;      // 경기 고유 ID
+    @Data
+    public static class ViewResult {
+        private String id;      // 경기 고유 ID
 
-		@JsonProperty("sport_id")
-		private String sportId; // 종목 ID
-		private String time;    // 경기 시작 시간 (UNIX TIMESTAMP)
+        @JsonProperty("sport_id")
+        private String sportId; // 종목 ID
+        private String time;    // 경기 시작 시간 (UNIX TIMESTAMP)
 
-		private String ss;      // 현재 스코어 정보 home:away
-		private Stats stats;
-		private Timer timer;
-		private Extra extra;
+        @JsonProperty("time_status")
+        private String timeStatus;
 
-		@JsonProperty("events")
-		private List<EventText> events; // 경기 중 발생한 이벤트 리스트
+        private String ss;      // 현재 스코어 정보 home:away
+        private Stats stats;
+        private Timer timer;
+        private Extra extra;
 
-		public MatchStats toMatchStats(int idx) {
-			if (this.stats == null)
-				return MatchStats.builder().build();
+        @JsonProperty("events")
+        private List<EventText> events; // 경기 중 발생한 이벤트 리스트
 
-			return MatchStats.builder()
-				.yellowCards(parse(stats.yellowCards, idx))
-				.redCards(parse(stats.redCards, idx))
-				.shots(parse(stats.shots, idx))
-				.shotsOnTarget(parse(stats.shotsOnTarget, idx))
-				.possession(parse(stats.possession, idx))
-				.offsides(parse(stats.offsides, idx))
-				.fouls(parse(stats.fouls, idx))
-				.corners(parse(stats.corners, idx))
-				.freeKicks(parse(stats.freeKicks, idx))
-				.build();
-		}
+        @JsonProperty("has_lineup")
+        private Integer hasLineup;  // 라인업 제공 여부 (0:제공안함, 1:제공함)
 
-		public MatchDetailDocument.ExtraTime toExtraTime() {
-			if (this.timer == null)
-				return defaultExtraTime();
+        public MatchDetailDocument toDocument(Long matchId) {
+            return MatchDetailDocument.builder()
+                    .id(matchId)
+                    .homeScore(getHomeScore())
+                    .homeStats(toMatchStats(0))
+                    .awayScore(getAwayScore())
+                    .awayStats(toMatchStats(1))
+                    .extraTime(toExtraTime())   // 추가시간
+                    .build();
+        }
 
-			return MatchDetailDocument.ExtraTime.builder()
-				.firstHalf(this.timer.getTa() != null ? this.timer.getTa() : 0)
-				.secondHalf(0)
-				.overTime(0)
-				.build();
-		}
+        public MatchStats toMatchStats(int idx) {
+            if (this.stats == null)
+                return MatchStats.builder().build();
 
-		private MatchDetailDocument.ExtraTime defaultExtraTime() {
-			return MatchDetailDocument.ExtraTime.builder()
-				.firstHalf(0)
-				.secondHalf(0)
-				.overTime(0)
-				.build();
-		}
+            return MatchStats.builder()
+                    .yellowCards(parse(stats.yellowCards, idx))
+                    .redCards(parse(stats.redCards, idx))
+                    .shots(parse(stats.shots, idx))
+                    .shotsOnTarget(parse(stats.shotsOnTarget, idx))
+                    .possession(parse(stats.possession, idx))
+                    .offsides(parse(stats.offsides, idx))
+                    .fouls(parse(stats.fouls, idx))
+                    .corners(parse(stats.corners, idx))
+                    .freeKicks(parse(stats.freeKicks, idx))
+                    .build();
+        }
 
-		private Integer parse(List<String> list, int i) {
-			try {
-				return (list != null && list.size() > i) ? Integer.parseInt(list.get(i)) : 0;
-			} catch (NumberFormatException e) {
-				return 0;
-			}
-		}
+        public MatchDetailDocument.ExtraTime toExtraTime() {
+            if (this.timer == null)
+                return defaultExtraTime();
 
-		public Integer getHomeScore() {
-			try {
-				if (ss != null) {
-					String[] parts = ss.split("-");
-					if (parts.length >= 1 && !parts[0].isEmpty())
-						return Integer.parseInt(parts[0]);
-				}
-			} catch (Exception e) {
-			}
-			return 0;
-		}
+            return MatchDetailDocument.ExtraTime.builder()
+                    .firstHalf(this.timer.getTa() != null ? this.timer.getTa() : 0)
+                    .secondHalf(0)
+                    .overTime(0)
+                    .build();
+        }
 
-		public Integer getAwayScore() {
-			try {
-				if (ss != null) {
-					String[] parts = ss.split("-");
-					if (parts.length >= 2 && !parts[1].isEmpty())
-						return Integer.parseInt(parts[1]);
-				}
-			} catch (Exception e) {
-			}
-			return 0;
-		}
-	}
+        private MatchDetailDocument.ExtraTime defaultExtraTime() {
+            return MatchDetailDocument.ExtraTime.builder()
+                    .firstHalf(0)
+                    .secondHalf(0)
+                    .overTime(0)
+                    .build();
+        }
 
-	@Data
-	public static class Stats {
-		@JsonProperty("yellow_cards")
-		private List<String> yellowCards;
-		@JsonProperty("red_cards")
-		private List<String> redCards;
-		@JsonProperty("shott_total")
-		private List<String> shots;
-		@JsonProperty("shott_on_target")
-		private List<String> shotsOnTarget;
-		@JsonProperty("possession_rt")
-		private List<String> possession;
-		@JsonProperty("offsides")
-		private List<String> offsides;
-		@JsonProperty("fouls")
-		private List<String> fouls;
-		@JsonProperty("corners")
-		private List<String> corners;
-		@JsonProperty("free_kicks")
-		private List<String> freeKicks;
-	}
+        private Integer parse(List<String> list, int i) {
+            try {
+                return (list != null && list.size() > i) ? Integer.parseInt(list.get(i)) : 0;
+            } catch (NumberFormatException e) {
+                return 0;
+            }
+        }
 
-	@Data
-	public static class Timer {
-		private Integer tm;     // 경과 분
-		private Integer ts;     // 경과 초
-		private String tt;      // 타이머 상태 (0:정지,1:진행)
-		private Integer ta;     // 추가시간
-	}
+        public Integer getHomeScore() {
+            try {
+                if (ss != null) {
+                    String[] parts = ss.split("-");
+                    if (parts.length >= 1 && !parts[0].isEmpty())
+                        return Integer.parseInt(parts[0]);
+                }
+            } catch (Exception e) {
+            }
+            return 0;
+        }
 
-	@Data
-	public static class EventText {
-		private String id;
-		private String text;
-	}
+        public Integer getAwayScore() {
+            try {
+                if (ss != null) {
+                    String[] parts = ss.split("-");
+                    if (parts.length >= 2 && !parts[1].isEmpty())
+                        return Integer.parseInt(parts[1]);
+                }
+            } catch (Exception e) {
+            }
+            return 0;
+        }
 
-	@Data
-	public static class Extra {
-		@JsonProperty("stadium_data")
-		private StadiumData stadiumData;
-	}
+        public boolean hasLineup() {
+            return hasLineup == 1;
+        }
+    }
 
-	@Data
-	public static class StadiumData {
-		private String id;              // 경기장 ID
-		private String name;            // 경기장명
-		private String city;            // 경기장이 위치한 도시
-	}
+    @Data
+    public static class Stats {
+        @JsonProperty("yellow_cards")
+        private List<String> yellowCards;
+        @JsonProperty("red_cards")
+        private List<String> redCards;
+        @JsonProperty("shott_total")
+        private List<String> shots;
+        @JsonProperty("shott_on_target")
+        private List<String> shotsOnTarget;
+        @JsonProperty("possession_rt")
+        private List<String> possession;
+        @JsonProperty("offsides")
+        private List<String> offsides;
+        @JsonProperty("fouls")
+        private List<String> fouls;
+        @JsonProperty("corners")
+        private List<String> corners;
+        @JsonProperty("free_kicks")
+        private List<String> freeKicks;
+    }
+
+    @Data
+    public static class Timer {
+        private Integer tm;     // 경과 분
+        private Integer ts;     // 경과 초
+        private String tt;      // 타이머 상태 (0:정지,1:진행)
+        private Integer ta;     // 추가시간
+    }
+
+    @Data
+    public static class EventText {
+        private String id;
+        private String text;
+    }
+
+    @Data
+    public static class Extra {
+        @JsonProperty("stadium_data")
+        private StadiumData stadiumData;
+    }
+
+    @Data
+    public static class StadiumData {
+        private String id;              // 경기장 ID
+        private String name;            // 경기장명
+        private String city;            // 경기장이 위치한 도시
+    }
 }

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsViewResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsViewResponse.java
@@ -15,7 +15,7 @@ public class BetsViewResponse {
 
     private List<ViewResult> results;
 
-    public boolean hasResult() {
+    public boolean hasResults() {
         return results != null && !results.isEmpty();
     }
 
@@ -129,7 +129,7 @@ public class BetsViewResponse {
         }
 
         public boolean hasLineup() {
-            return hasLineup == 1;
+            return hasLineup != null && hasLineup == 1;
         }
     }
 

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/repository/FakeMatchDetailRepository.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/repository/FakeMatchDetailRepository.java
@@ -1,6 +1,7 @@
 package com.scorenow.scorenow_api.domain.match.repository;
 
 import com.scorenow.scorenow_api.domain.match.document.MatchDetailDocument;
+import com.scorenow.scorenow_api.domain.match.document.MatchDetailDocument.ExtraTime;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.HashMap;
@@ -36,6 +37,40 @@ public class FakeMatchDetailRepository implements MatchDetailRepository {
         matchDetailDocuments.forEach(matchDetailDocument -> matchDetailDocument.updateCurrentCommentary(content, commentaryId));
 
         return matchDetailDocuments.size();
+    }
+
+    @Override
+    public void upsertMatchDetail(MatchDetailDocument matchDetailDocument) {
+        Long id = matchDetailDocument.getId();
+        MatchDetailDocument saved = database.get(id);
+
+        if (saved == null) {
+            save(matchDetailDocument);
+            return;
+        }
+
+        ReflectionTestUtils.setField(saved, "homeScore", matchDetailDocument.getHomeScore());
+        ReflectionTestUtils.setField(saved, "homeStats", matchDetailDocument.getHomeStats());
+        ReflectionTestUtils.setField(saved, "awayScore", matchDetailDocument.getAwayScore());
+        ReflectionTestUtils.setField(saved, "awayStats", matchDetailDocument.getAwayStats());
+
+        ExtraTime newExtraTime = matchDetailDocument.getExtraTime();
+        if (newExtraTime != null) {
+            ExtraTime existingExtraTime = saved.getExtraTime();
+
+            if (existingExtraTime == null) {
+                // 기존 추가시간 객체가 아예 없었다면 객체 자체를 통째로 할당
+                ReflectionTestUtils.setField(saved, "extraTime", newExtraTime);
+            } else {
+                // 기존 추가시간 객체가 있다면, 하위 필드(전반/후반) 별로 null이 아닐 때만 병합
+                if (newExtraTime.getFirstHalf() != null) {
+                    ReflectionTestUtils.setField(existingExtraTime, "firstHalf", newExtraTime.getFirstHalf());
+                }
+                if (newExtraTime.getSecondHalf() != null) {
+                    ReflectionTestUtils.setField(existingExtraTime, "secondHalf", newExtraTime.getSecondHalf());
+                }
+            }
+        }
     }
 
 }

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchDetailSyncServiceTest.java
@@ -1,0 +1,264 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import com.scorenow.scorenow_api.domain.match.document.MatchLineupDocument;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+import com.scorenow.scorenow_api.domain.match.redis.InplayRedisService;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import com.scorenow.scorenow_api.domain.match.repository.mongo.MatchLineupRepository;
+import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsViewResponse.ViewResult;
+import com.scorenow.scorenow_api.external.common.ApiProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MatchDetailSyncServiceTest {
+
+    @InjectMocks
+    private MatchDetailSyncService matchDetailSyncService;
+
+    @Mock
+    private BetsApiClient betsApiClient;
+    @Mock
+    private MatchRepository matchRepository;
+    @Mock
+    private MatchLineupRepository matchLineupRepository;
+    @Mock
+    private MatchDetailService matchDetailService;
+    @Mock
+    private InplayRedisService inplayRedisService;
+    @Mock
+    private MatchLineupGoalsService matchLineupGoalsService;
+
+    // =========================================================================
+    // 1. 조기 종료 (Early Return) 관련
+    // =========================================================================
+
+    @Test
+    @DisplayName("진행 중(IN_PLAY)인 경기가 없으면 API를 호출하지 않고 조기 종료한다.")
+    void syncInplayMatchDetails_WhenNoInplayMatches_ThenReturnEarly() {
+        // given
+        given(matchRepository.findByStatusCodeAndIsManualFalse(MatchStatus.IN_PLAY))
+                .willReturn(Collections.emptyList());
+
+        // when
+        matchDetailSyncService.syncInplayMatchDetails();
+
+        // then
+        verify(betsApiClient, never()).getEventView(anyString());
+        verify(matchDetailService, never()).updateInplayMatchDetail(any(), any());
+    }
+
+    // =========================================================================
+    // 2. 외부 API 호출 관련
+    // =========================================================================
+
+    @Test
+    @DisplayName("조회된 경기가 10개를 초과할 경우 API를 10개 단위로 분할하여 호출한다.")
+    void syncInplayMatchDetails_WhenMatchesExceedBatchSize_ThenCallApiInBatches() {
+        // given
+        List<Match> matches = createMockMatches(12);
+        given(matchRepository.findByStatusCodeAndIsManualFalse(MatchStatus.IN_PLAY)).willReturn(matches);
+
+        given(betsApiClient.getEventView(anyString())).willReturn(createMockResponse());
+
+        // when
+        matchDetailSyncService.syncInplayMatchDetails();
+
+        // then
+        // 12개이므로 10개짜리 1번, 2개짜리 1번 총 2번 호출되어야 함
+        verify(betsApiClient, times(2)).getEventView(anyString());
+    }
+
+    @Test
+    @DisplayName("여러 번의 외부 API 호출 중 일부가 실패하더라도 다음 외부 API 호출은 정상 진행된다.")
+    void syncInplayMatchDetails_WhenOneBatchFails_ThenContinueNextBatch() {
+        // given
+        List<Match> matches = createMockMatches(12); // 배치 2개 생성됨
+        given(matchRepository.findByStatusCodeAndIsManualFalse(MatchStatus.IN_PLAY)).willReturn(matches);
+
+        // 첫 번째 외부 API 호출 시 예외 발생, 두 번째 외부 API 호출 시 정상 응답하도록 설정
+        given(betsApiClient.getEventView(anyString()))
+                .willThrow(new RuntimeException("외부 API 호출중 Timeout 발생"))
+                .willReturn(createMockResponse());
+
+        // when
+        matchDetailSyncService.syncInplayMatchDetails();
+
+        // then
+        verify(betsApiClient, times(2)).getEventView(anyString()); // 예외가 나도 두 번 모두 호출됨
+    }
+
+    // =========================================================================
+    // 3. 비즈니스 처리 관련
+    // =========================================================================
+
+    @Test
+    @DisplayName("API 응답에 해당 경기 상세 정보가 누락된 경우 처리를 스킵한다.")
+    void syncInplayMatchDetails_WhenMatchDetailIsMissingInApi_ThenSkip() {
+        // given
+        Match match = createMockMatch(1L, "api-100");
+        given(matchRepository.findByStatusCodeAndIsManualFalse(MatchStatus.IN_PLAY)).willReturn(List.of(match));
+
+        BetsViewResponse emptyResponse = new BetsViewResponse();
+        emptyResponse.setResults(Collections.emptyList()); // 응답에 결과가 없음
+        given(betsApiClient.getEventView("api-100")).willReturn(emptyResponse);
+
+        // when
+        matchDetailSyncService.syncInplayMatchDetails();
+
+        // then
+        verify(matchDetailService, never()).updateInplayMatchDetail(any(), any());
+    }
+
+    @Test
+    @DisplayName("API 응답에 라인업 정보가 없는 경우 Detail만 업데이트하고 라인업-골 동기화 로직은 스킵한다.")
+    void syncInplayMatchDetails_WhenNoLineupProvided_ThenSkipLineupGoalLogic() {
+        // given
+        Match match = createMockMatch(1L, "api-100");
+        given(matchRepository.findByStatusCodeAndIsManualFalse(MatchStatus.IN_PLAY)).willReturn(List.of(match));
+
+        ViewResult viewResult = createMockViewResult("api-100", false); // 라인업 제공 안함
+        BetsViewResponse response = createMockResponse(viewResult);
+        given(betsApiClient.getEventView("api-100")).willReturn(response);
+
+        // when
+        matchDetailSyncService.syncInplayMatchDetails();
+
+        // then
+        verify(matchDetailService, times(1)).updateInplayMatchDetail(ApiProvider.BETS, viewResult);
+        verify(inplayRedisService, never()).markSeenAndEnqueue(anyString(), anyString());
+        verify(matchLineupGoalsService, never()).updateLineupGoals((MatchLineupDocument) any(), any());
+    }
+
+    @Test
+    @DisplayName("라인업은 제공되었으나 MatchLineupDocument가 없으면 Redis 의 NEW_LINEUP_QUEUE에 삽입하고 루프를 종료한다.")
+    void syncInplayMatchDetails_WhenLineupProvidedButNoLocalDoc_ThenEnqueueToRedis() {
+        // given
+        Match match = createMockMatch(1L, "api-100");
+        given(matchRepository.findByStatusCodeAndIsManualFalse(MatchStatus.IN_PLAY)).willReturn(List.of(match));
+
+        ViewResult viewResult = createMockViewResult("api-100", true);
+        BetsViewResponse response = createMockResponse(viewResult);
+        given(betsApiClient.getEventView("api-100")).willReturn(response);
+
+        // 로컬 DB에 라인업 문서가 없는 상태
+        given(matchLineupRepository.findByIdIn(List.of(1L))).willReturn(Collections.emptyList());
+        given(inplayRedisService.markSeenAndEnqueue("1", "10")).willReturn(true);
+
+        // when
+        matchDetailSyncService.syncInplayMatchDetails();
+
+        // then
+        verify(matchDetailService, times(1)).updateInplayMatchDetail(ApiProvider.BETS, viewResult);
+        verify(inplayRedisService, times(1)).markSeenAndEnqueue("1", "10");
+        verify(matchLineupGoalsService, never()).updateLineupGoals((MatchLineupDocument) any(), any()); // 골 업데이트는 스킵됨
+    }
+
+    @Test
+    @DisplayName("라인업이 제공되고 MatchLineupDocument도 이미 존재하면 라인업-골 동기화 로직을 수행한다.")
+    void syncInplayMatchDetails_WhenLineupProvidedAndLocalDocExists_ThenUpdateLineupGoals() {
+        // given
+        Match match = createMockMatch(1L, "api-100");
+        given(matchRepository.findByStatusCodeAndIsManualFalse(MatchStatus.IN_PLAY)).willReturn(List.of(match));
+
+        ViewResult viewResult = createMockViewResult("api-100", true);
+        BetsViewResponse response = createMockResponse(viewResult);
+        given(betsApiClient.getEventView("api-100")).willReturn(response);
+
+        MatchLineupDocument document = mock(MatchLineupDocument.class);
+        given(document.getId()).willReturn(1L);
+        given(matchLineupRepository.findByIdIn(List.of(1L))).willReturn(List.of(document));
+
+        // when
+        matchDetailSyncService.syncInplayMatchDetails();
+
+        // then
+        verify(matchDetailService, times(1)).updateInplayMatchDetail(ApiProvider.BETS, viewResult);
+        verify(inplayRedisService, never()).markSeenAndEnqueue(anyString(), anyString()); // 큐 삽입 안함
+        verify(matchLineupGoalsService, times(1)).updateLineupGoals(document, viewResult);
+    }
+
+    // =========================================================================
+    // 4. 예외 격리 관련
+    // =========================================================================
+
+    @Test
+    @DisplayName("특정 경기 세부 정보 업데이트 중 예외가 발생해도, 다음 경기의 업데이트는 정상적으로 진행된다.")
+    void syncInplayMatchDetails_WhenExceptionDuringUpdate_ThenContinueWithNextMatch() {
+        // given
+        Match match1 = createMockMatch(1L, "api-100");
+        Match match2 = createMockMatch(2L, "api-200");
+        given(matchRepository.findByStatusCodeAndIsManualFalse(MatchStatus.IN_PLAY))
+                .willReturn(List.of(match1, match2));
+
+        ViewResult result1 = createMockViewResult("api-100", false);
+        ViewResult result2 = createMockViewResult("api-200", false);
+        BetsViewResponse response = createMockResponse(result1, result2);
+        given(betsApiClient.getEventView("api-100,api-200")).willReturn(response);
+
+        // 첫 번째 경기 업데이트 시 예외 발생 유도
+        willThrow(new RuntimeException("DB Deadlock"))
+                .given(matchDetailService).updateInplayMatchDetail(ApiProvider.BETS, result1);
+
+        // when
+        matchDetailSyncService.syncInplayMatchDetails();
+
+        // then
+        // match1 업데이트에서 예외가 났지만, match2 업데이트까지 도달해서 총 2번의 호출 시도가 있었는지 검증
+        verify(matchDetailService, times(1)).updateInplayMatchDetail(ApiProvider.BETS, result1);
+        verify(matchDetailService, times(1)).updateInplayMatchDetail(ApiProvider.BETS, result2);
+    }
+
+
+    private Match createMockMatch(Long id, String apiMatchId) {
+        Match match = mock(Match.class);
+        lenient().when(match.getId()).thenReturn(id);
+        lenient().when(match.getSportId()).thenReturn(10L); // Default Sport ID
+        lenient().when(match.getApiMatchId()).thenReturn(apiMatchId);
+        return match;
+    }
+
+    private List<Match> createMockMatches(int count) {
+        List<Match> matches = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            matches.add(createMockMatch((long) i, "api-" + i));
+        }
+        return matches;
+    }
+
+    private ViewResult createMockViewResult(String id, boolean hasLineup) {
+        ViewResult result = mock(ViewResult.class);
+        lenient().when(result.getId()).thenReturn(id);
+        lenient().when(result.hasLineup()).thenReturn(hasLineup);
+        return result;
+    }
+
+    private BetsViewResponse createMockResponse() {
+        BetsViewResponse betsViewResponse = new BetsViewResponse();
+        betsViewResponse.setResults(new ArrayList<>());
+        return betsViewResponse;
+    }
+
+    private BetsViewResponse createMockResponse(ViewResult... results) {
+        BetsViewResponse response = new BetsViewResponse();
+        response.setResults(List.of(results));
+        return response;
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number
> 이슈번호 : #70 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
1. 분산되어 있던 Event View API 호출 로직을 한 곳으로 통합
    - 변경 전 : MatchDetailScheduler (경기 중계), MatchLineupGoalSyncScheduler (라인업-골 동기화) 
    - 변경 후 : MatchDetailScheduler

2. 단건으로 Event View 호출 하는 방식을 한번에 최대 10경기를 일괄 호출하는 방식으로 변경
    - 변경 전 : 11 건의 경기에 대한 Event View 호출 시 11 번의 API 요청이 발생
    - 변경 후 : 11 건의 경기에 대한 Event View 호출 시 2 번의 API 요청이 발생 
    `11건 → 10건 + 1건 / 10건 → 1번 호출 / 1건 → 1번 호출 / 총 2번 호출`

3. `IN_PLAY → ENDED` 경기 동기화 작업을 Event View API 를 통해 처리

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
1. 현재 사용중인 Bets 요금제에 따라서 Event View API 호출 주기는 1분으로 설정하였습니다.
이 부분은 운영팀 문의 결과 15초에서 30초 주기로 호출해야 한다는 답변을 받았고, 추후 서비스 런칭 시 요금제를 업그레이드 하는 방식으로 개선하면 될 것 같습니다.
2. InplayScanShceduler,  MatchLineupGoalScheduler 를 더 이상 사용하지 않아도 될 것 같은데 이 부분 확인이 필요합니다. @hailyn-k 
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
