### PR TITLE
feat: 경기 별 "홈-어웨이 / 어웨이-홈" 표기 정책 관련 기능 개발

### DIFF
--- a/src/main/java/com/scorenow/scorenow_api/domain/common/enums/TeamDisplayOrder.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/common/enums/TeamDisplayOrder.java
@@ -1,0 +1,19 @@
+package com.scorenow.scorenow_api.domain.common.enums;
+
+import java.util.List;
+
+public enum TeamDisplayOrder {
+    HOME_AWAY(List.of("HOME", "AWAY")),
+    AWAY_HOME(List.of("AWAY", "HOME"));
+
+    private final List<String> displaySides;
+
+    TeamDisplayOrder(List<String> displaySides) {
+        this.displaySides = displaySides;
+    }
+
+    public List<String> toDisplaySides() {
+        return displaySides;
+    }
+
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueCreateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueCreateRequest.java
@@ -1,6 +1,7 @@
 package com.scorenow.scorenow_api.domain.league.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -11,16 +12,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LeagueCreateRequest {
 
-	@NotNull(message = "종목ID 는 필수입니다.")
-	private Long sportId;
+    @NotNull(message = "종목ID 는 필수입니다.")
+    private Long sportId;
 
-	@NotBlank
-	@JsonProperty("eName")
-	private String eName;
+    @NotBlank
+    @JsonProperty("eName")
+    private String eName;
 
-	@JsonProperty("kName")
-	private String kName;
+    @JsonProperty("kName")
+    private String kName;
 
-	@JsonProperty("sName")
-	private String sName;
+    @JsonProperty("sName")
+    private String sName;
+
+    @JsonProperty("teamDisplayOrder")
+    private TeamDisplayOrder teamDisplayOrder;
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueUpdateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.scorenow.scorenow_api.domain.league.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,4 +20,7 @@ public class LeagueUpdateRequest {
 
 	@JsonProperty("sName")
 	private String sName;
+
+	@JsonProperty("teamDisplayOrder")
+	private TeamDisplayOrder teamDisplayOrder;
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/response/LeagueAdminResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/response/LeagueAdminResponse.java
@@ -1,5 +1,6 @@
 package com.scorenow.scorenow_api.domain.league.dto.response;
 
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
 import com.scorenow.scorenow_api.domain.league.entity.League;
 
 import lombok.Builder;
@@ -14,6 +15,7 @@ public class LeagueAdminResponse {
     private String kName;
     private String eName;
     private String sName;
+    private TeamDisplayOrder teamDisplayOrder;
 
     public static LeagueAdminResponse from(League league) {
         return LeagueAdminResponse.builder()
@@ -22,6 +24,7 @@ public class LeagueAdminResponse {
                 .kName(league.getKName())
                 .eName(league.getEName())
                 .sName(league.getSName())
+                .teamDisplayOrder(league.getTeamDisplayOrder())
                 .build();
     }
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/entity/League.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/entity/League.java
@@ -1,48 +1,68 @@
 package com.scorenow.scorenow_api.domain.league.entity;
 
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
 import com.scorenow.scorenow_api.global.entity.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(name = "leagues",
-	uniqueConstraints = {
-		@UniqueConstraint(
-			name = "uk_leagues",
-			columnNames = {"sport_id", "e_name"})})
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_leagues",
+                        columnNames = {"sport_id", "e_name"})})
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 public class League extends BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@Column(name = "sport_id")
-	private Long sportId;
+    @Column(name = "sport_id")
+    private Long sportId;
 
-	@Column(name = "k_name")
-	private String kName;
+    @Column(name = "k_name")
+    private String kName;
 
-	@Column(name = "e_name")
-	private String eName;
+    @Column(name = "e_name")
+    private String eName;
 
-	@Column(name = "s_name")
-	private String sName; // 숏네임
+    @Column(name = "s_name")
+    private String sName; // 숏네임
 
-	private String cc;
+    private String cc;
+
+    @Enumerated(EnumType.STRING)
+    private TeamDisplayOrder teamDisplayOrder;
+
+    public void updateSportId(Long sportId) {
+        this.sportId = sportId;
+    }
+
+    public void updateEName(String eName) {
+        this.eName = eName;
+    }
+
+    public void updateKName(String kName) {
+        this.kName = kName;
+    }
+
+    public void updateSName(String sName) {
+        this.sName = sName;
+    }
+
+    public void updateTeamDisplayOrder(TeamDisplayOrder teamDisplayOrder) {
+        this.teamDisplayOrder = teamDisplayOrder;
+    }
+
+    public boolean hasTeamDisplayOrder() {
+        return teamDisplayOrder != null;
+    }
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueAdminService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueAdminService.java
@@ -47,10 +47,11 @@ public class LeagueAdminService {
         League league = leagueRepository.findById(leagueId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.LEAGUE_NOT_FOUND));
 
-        if (request.getSportId() != null) league.setSportId(request.getSportId());
-        if (request.getEName() != null) league.setEName(request.getEName());
-        if (request.getKName() != null) league.setKName(request.getKName());
-        if (request.getSName() != null) league.setSName(request.getSName());
+        if (request.getSportId() != null) league.updateSportId(request.getSportId());
+        if (request.getEName() != null) league.updateEName(request.getEName());
+        if (request.getKName() != null) league.updateKName(request.getKName());
+        if (request.getSName() != null) league.updateSName(request.getSName());
+        if (request.getTeamDisplayOrder() != null) league.updateTeamDisplayOrder(request.getTeamDisplayOrder());
     }
 
     @Transactional

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueAdminService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueAdminService.java
@@ -37,6 +37,7 @@ public class LeagueAdminService {
                 .eName(request.getEName())
                 .kName(request.getKName())
                 .sName(request.getSName())
+                .teamDisplayOrder(request.getTeamDisplayOrder())
                 .build();
 
         return LeagueAdminResponse.from(leagueRepository.save(league));

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueService.java
@@ -24,20 +24,33 @@ public class LeagueService {
      * 경기장 생성
      */
     @Transactional
-    public League getOrCreateLeague(final ApiProvider provider, final Long internalSportId, final String apiLeagueId, final String name, final String cc) {
+    public League getOrCreateLeague(
+            final ApiProvider provider,
+            final Long internalSportId,
+            final String apiLeagueId,
+            final String name,
+            final String cc) {
+
         // 1. 전달받은 외부 정보를 기반으로 League External Mapping 테이블에 데이터가 있는지 확인
         Optional<LeagueExternalMapping> leagueMappingInfo = leagueExternalMappingRepository.findByExternalInfo(provider, apiLeagueId);
 
         // 2. 매핑 정보에서 internal league id 를 추출하고, 이를 기반으로 League 엔티티 반환
         if (leagueMappingInfo.isPresent()) {
             Long internalLeagueId = leagueMappingInfo.get().getInternalLeagueId();
-            return leagueRepository.findById(internalLeagueId).orElseGet(() -> createAndMapLeague(provider, internalSportId, apiLeagueId, name, cc));
+            return leagueRepository.findById(internalLeagueId)
+                    .orElseGet(() -> createAndMapLeague(provider, internalSportId, apiLeagueId, name, cc));
         }
 
         return createAndMapLeague(provider, internalSportId, apiLeagueId, name, cc);
     }
 
-    private League createAndMapLeague(ApiProvider provider, Long internalSportId, String apiLeagueId, String name, String cc) {
+    private League createAndMapLeague(
+            ApiProvider provider,
+            Long internalSportId,
+            String apiLeagueId,
+            String name,
+            String cc) {
+
         League savedLeague = leagueRepository.save(League.builder()
                 .sportId(internalSportId)
                 .kName(name)

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchCreateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchCreateRequest.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchUpdateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/request/MatchUpdateRequest.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -18,6 +20,9 @@ public class MatchUpdateRequest {
 	private Integer awayScore;
 
 	private Boolean isActive;
+
+	@JsonProperty("teamDisplayOrder")
+	private TeamDisplayOrder teamDisplayOrder;
 
 	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
 	private LocalDateTime startAt;

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchListResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchListResponse.java
@@ -1,6 +1,7 @@
 package com.scorenow.scorenow_api.domain.match.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -10,25 +11,26 @@ import lombok.Getter;
 @Getter
 @Builder
 public class MatchListResponse {
-	private Long id;
-	private Long sportId;
-	private String sportName;
-	private Long leagueId;
-	private String leagueName;
-	private String matchType;
-	private String statusCode;
-	private String statusName;
-	private Long homeId;
-	private String homeName;
-	private String homeImageUrl;
-	private Integer homeScore;
-	private Long awayId;
-	private String awayName;
-	private String awayImageUrl;
-	private Integer awayScore;
-	private boolean isManual;
-	private boolean isActive;
+    private Long id;
+    private Long sportId;
+    private String sportName;
+    private Long leagueId;
+    private String leagueName;
+    private String matchType;
+    private String statusCode;
+    private String statusName;
+    private Long homeId;
+    private String homeName;
+    private String homeImageUrl;
+    private Integer homeScore;
+    private Long awayId;
+    private String awayName;
+    private String awayImageUrl;
+    private Integer awayScore;
+    private boolean isManual;
+    private boolean isActive;
+    private List<String> teamDisplayOrder;
 
-	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-	private LocalDateTime startAt;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime startAt;
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/Match.java
@@ -2,6 +2,7 @@ package com.scorenow.scorenow_api.domain.match.entity;
 
 import java.time.LocalDateTime;
 
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
 import com.scorenow.scorenow_api.domain.league.entity.League;
 import com.scorenow.scorenow_api.domain.sport.entity.Sport;
 import com.scorenow.scorenow_api.domain.stadium.entity.TemporaryStadium;
@@ -34,67 +35,71 @@ public class Match extends BaseEntity {
     @Column(name = "api_match_id")
     private String apiMatchId;
 
-	private Long leagueId;
-	private Long sportId;
+    private Long leagueId;
+    private Long sportId;
 
-	private Long homeId;
-	private Long awayId;
+    private Long homeId;
+    private Long awayId;
 
-	@Enumerated(EnumType.STRING)
-	private MatchStatus statusCode;
+    @Enumerated(EnumType.STRING)
+    private MatchStatus statusCode;
 
-	private Integer homeScore;
-	private Integer awayScore;
-	private LocalDateTime startAt;
+    private Integer homeScore;
+    private Integer awayScore;
+    private LocalDateTime startAt;
 
-	private Long stadiumId;
+    private Long stadiumId;
 
-	@Embedded
-	private TemporaryStadium temporaryStadium;
+    @Embedded
+    private TemporaryStadium temporaryStadium;
 
-	@Builder.Default
-	private String matchType = "A"; // 기본 A로 세팅
+    @Builder.Default
+    private String matchType = "A"; // 기본 A로 세팅
 
-	@Builder.Default
-	private boolean isManual = false;
+    @Builder.Default
+    private boolean isManual = false;
 
-	@Builder.Default
-	private boolean isActive = true;
+    @Builder.Default
+    private boolean isActive = true;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private TeamDisplayOrder teamDisplayOrder = TeamDisplayOrder.HOME_AWAY;
 
     private String bet365Id;
 
-	// JPA 관계 추가 (Fetch join용)
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "leagueId", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-	private League league;
+    // JPA 관계 추가 (Fetch join용)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leagueId", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private League league;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "sportId", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-	private Sport sport;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sportId", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Sport sport;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "homeId", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-	private Team homeTeam;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "homeId", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Team homeTeam;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "awayId", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-	private Team awayTeam;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "awayId", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Team awayTeam;
 
-	public void updateSportId(Long sportId) {
-		this.sportId = sportId;
-	}
+    public void updateSportId(Long sportId) {
+        this.sportId = sportId;
+    }
 
-	public void updateLeagueId(Long leagueId) {
-		this.leagueId = leagueId;
-	}
+    public void updateLeagueId(Long leagueId) {
+        this.leagueId = leagueId;
+    }
 
-	public void updateHomeId(Long homeId) {
-		this.homeId = homeId;
-	}
+    public void updateHomeId(Long homeId) {
+        this.homeId = homeId;
+    }
 
-	public void updateAwayId(Long awayId) {
-		this.awayId = awayId;
-	}
+    public void updateAwayId(Long awayId) {
+        this.awayId = awayId;
+    }
 
     public void updateStartAt(LocalDateTime startAt) {
         this.startAt = startAt;
@@ -124,6 +129,10 @@ public class Match extends BaseEntity {
     public void assignTemporaryStadium(String stadiumName, String city) {
         this.stadiumId = null;  // 기존에 자동으로 매핑된 경기장 정보가 있다면 해제
         this.temporaryStadium = new TemporaryStadium(stadiumName, city);
+    }
+
+    public void updateTeamDisplayOrder(TeamDisplayOrder teamDisplayOrder) {
+        this.teamDisplayOrder = teamDisplayOrder;
     }
 
     public boolean isStadiumEmpty() {

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/mapper/MatchMapper.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/mapper/MatchMapper.java
@@ -1,5 +1,6 @@
 package com.scorenow.scorenow_api.domain.match.mapper;
 
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
 import org.springframework.stereotype.Component;
 
 import com.scorenow.scorenow_api.domain.league.entity.League;
@@ -9,6 +10,8 @@ import com.scorenow.scorenow_api.domain.match.entity.Match;
 import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
 import com.scorenow.scorenow_api.domain.sport.entity.Sport;
 import com.scorenow.scorenow_api.domain.team.entity.Team;
+
+import java.util.List;
 
 @Component
 public class MatchMapper {
@@ -34,6 +37,7 @@ public class MatchMapper {
                 .awayScore(match.getAwayScore())
                 .isManual(match.isManual())
                 .isActive(match.isActive())
+                .teamDisplayOrder(getTeamDisplayOrder(match))
                 .build();
     }
 
@@ -66,4 +70,11 @@ public class MatchMapper {
     private String getTeamImageUrl(Team team) {
         return team != null ? team.getImageUrl() : null;
     }
+
+    private List<String> getTeamDisplayOrder(Match match) {
+        return match.getTeamDisplayOrder() != null
+                ? match.getTeamDisplayOrder().toDisplaySides()
+                : TeamDisplayOrder.HOME_AWAY.toDisplaySides();
+    }
+
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminService.java
@@ -1,5 +1,7 @@
 package com.scorenow.scorenow_api.domain.match.service;
 
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
+import com.scorenow.scorenow_api.domain.league.entity.League;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -28,95 +30,118 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class MatchAdminService {
 
-	private final MatchRepository matchRepository;
-	private final LeagueRepository leagueRepository;
-	private final TeamRepository teamRepository;
-	private final SportRepository sportRepository;
-	private final MatchMapper matchMapper;
+    private final MatchRepository matchRepository;
+    private final LeagueRepository leagueRepository;
+    private final TeamRepository teamRepository;
+    private final SportRepository sportRepository;
 
-	/**
-	 * 경기 리스트 조회
-	 */
-	public Page<MatchListResponse> getMatches(MatchSearchCondition condition, Pageable pageable) {
-		return matchRepository.searchMatches(condition, pageable)
-			.map(matchMapper::toResponse);
-	}
+    private final MatchMapper matchMapper;
 
-	/**
-	 * 경기 수동 등록
-	 */
-	@Transactional
-	public MatchListResponse createMatch(MatchCreateRequest request) {
-		validateMatchCreateRequest(request);
+    private final MatchTeamDisplayOrderPolicy matchTeamDisplayOrderPolicy;
 
-		Match match = matchMapper.toEntity(request);
-		matchRepository.save(match);
+    /**
+     * 경기 리스트 조회
+     */
+    public Page<MatchListResponse> getMatches(MatchSearchCondition condition, Pageable pageable) {
+        return matchRepository.searchMatches(condition, pageable)
+                .map(matchMapper::toResponse);
+    }
 
-		log.info("수동 경기 등록 완료 - matchId: {}", match.getId());
+    /**
+     * 경기 수동 등록
+     * <p>
+     * 경기 수동 등록할 때, 리그 정보도 넣어준다.
+     * 기본적으로 리그 정보를 자동으로 따라가게 하고, 그게 아니면 home-away 로 세팅
+     * <p>
+     * 정리하면 MatchCreateRequest 에서는 displayOrder 를 따로 전달받지 않고 League 정보 기반으로 추론한다.
+     * League 로 추론이 불가능한 경우, 기본값인 HOME_AWAY 들어감.
+     */
+    @Transactional
+    public MatchListResponse createMatch(MatchCreateRequest request) {
+        validateMatchCreateRequest(request);
 
-		return matchRepository.findByIdWithRelations(match.getId())
-			.map(matchMapper::toResponse)
-			.orElseGet(() -> matchMapper.toResponse(match));
-	}
+        Match match = matchMapper.toEntity(request);
 
-	/**
-	 * 경기 수정
-	 */
-	@Transactional
-	public void updateMatch(Long matchId, MatchUpdateRequest request) {
-		Match match = findMatchById(matchId);
+        League league = leagueRepository.findById(request.getLeagueId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.LEAGUE_NOT_FOUND));
 
-		applyUpdates(match, request);
+        TeamDisplayOrder teamDisplayOrder = matchTeamDisplayOrderPolicy.decide(league);
+        match.updateTeamDisplayOrder(teamDisplayOrder);
 
-		log.info("경기 수정 완료 - matchId: {}", matchId);
-	}
+        matchRepository.save(match);
 
-	// === Validation Methods ===
+        log.info("수동 경기 등록 완료 - matchId: {}", match.getId());
 
-	private void validateMatchCreateRequest(MatchCreateRequest request) {
-		if (!leagueRepository.existsById(request.getLeagueId())) {
-			throw new BusinessException(ErrorCode.LEAGUE_NOT_FOUND);
-		}
-		if (!teamRepository.existsById(request.getHomeId())) {
-			throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "홈팀을 찾을 수 없습니다.");
-		}
-		if (!teamRepository.existsById(request.getAwayId())) {
-			throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "원정팀을 찾을 수 없습니다.");
-		}
-		if (request.getSportId() != null && !sportRepository.existsById(request.getSportId())) {
-			throw new BusinessException(ErrorCode.SPORT_NOT_FOUND);
-		}
-	}
+        return matchRepository.findByIdWithRelations(match.getId())
+                .map(matchMapper::toResponse)
+                .orElseGet(() -> matchMapper.toResponse(match));
+    }
 
-	// === Helper Methods ===
+    /**
+     * 경기 수정
+     */
+    @Transactional
+    public void updateMatch(Long matchId, MatchUpdateRequest request) {
+        Match match = findMatchById(matchId);
 
-	private Match findMatchById(Long matchId) {
-		return matchRepository.findById(matchId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.MATCH_NOT_FOUND));
-	}
+        applyUpdates(match, request);
 
-	private void applyUpdates(Match match, MatchUpdateRequest request) {
-		if (request.getStartAt() != null) {
-			match.updateStartAt(request.getStartAt());
-		}
-		if (request.getStatusCode() != null) {
-			try {
-				match.updateStatus(MatchStatus.valueOf(request.getStatusCode()));
-			} catch (IllegalArgumentException e) {
-				throw new BusinessException(ErrorCode.MATCH_INVALID_STATUS);
-			}
-		}
-		if (request.getHomeScore() != null) {
-			match.updateHomeScore(request.getHomeScore());
-		}
-		if (request.getAwayScore() != null) {
-			match.updateAwayScore(request.getAwayScore());
-		}
-		if (request.getIsActive() != null) {
-			match.updateIsActive(request.getIsActive());
-		}
-	}
+        log.info("경기 수정 완료 - matchId: {}", matchId);
+    }
 
+    // === Validation Methods ===
+
+    private void validateMatchCreateRequest(MatchCreateRequest request) {
+        if (!leagueRepository.existsById(request.getLeagueId())) {
+            throw new BusinessException(ErrorCode.LEAGUE_NOT_FOUND);
+        }
+        if (!teamRepository.existsById(request.getHomeId())) {
+            throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "홈팀을 찾을 수 없습니다.");
+        }
+        if (!teamRepository.existsById(request.getAwayId())) {
+            throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "원정팀을 찾을 수 없습니다.");
+        }
+        if (request.getSportId() != null && !sportRepository.existsById(request.getSportId())) {
+            throw new BusinessException(ErrorCode.SPORT_NOT_FOUND);
+        }
+    }
+
+    // === Helper Methods ===
+
+    private Match findMatchById(Long matchId) {
+        return matchRepository.findById(matchId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MATCH_NOT_FOUND));
+    }
+
+    private void applyUpdates(Match match, MatchUpdateRequest request) {
+        if (request.getStartAt() != null) {
+            match.updateStartAt(request.getStartAt());
+        }
+
+        if (request.getStatusCode() != null) {
+            try {
+                match.updateStatus(MatchStatus.valueOf(request.getStatusCode()));
+            } catch (IllegalArgumentException e) {
+                throw new BusinessException(ErrorCode.MATCH_INVALID_STATUS);
+            }
+        }
+
+        if (request.getHomeScore() != null) {
+            match.updateHomeScore(request.getHomeScore());
+        }
+
+        if (request.getAwayScore() != null) {
+            match.updateAwayScore(request.getAwayScore());
+        }
+
+        if (request.getIsActive() != null) {
+            match.updateIsActive(request.getIsActive());
+        }
+
+        if (request.getTeamDisplayOrder() != null) {
+            match.updateTeamDisplayOrder(request.getTeamDisplayOrder());
+        }
+    }
 
 
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchEventSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchEventSyncService.java
@@ -35,6 +35,7 @@ public class MatchEventSyncService {
 
     private final LeagueService leagueService;
     private final TeamService teamService;
+    private final MatchTeamDisplayOrderPolicy matchTeamDisplayOrderPolicy;
 
     private final MatchRepository matchRepository;
 
@@ -53,12 +54,14 @@ public class MatchEventSyncService {
         League savedLeague = saveLeague(provider, event.getLeague(), internalSportId);
         Team savedHome = saveTeam(provider, event.getHome(), internalSportId);
         Team savedAway = saveTeam(provider, event.getAway(), internalSportId);
-        saveMatch(provider, event, internalSportId, savedLeague.getId(), savedHome.getId(), savedAway.getId());
+        saveMatch(provider, event, internalSportId, savedLeague, savedHome, savedAway);
     }
 
     private League saveLeague(ApiProvider provider, BetsEventResponse.League betsLeague, Long internalSportId) {
         if (betsLeague == null) {
-            throw new BusinessException(ErrorCode.LEAGUE_NOT_FOUND, String.format("%s 에서 리그 정보를 제공하지 않았습니다.", provider));
+            throw new BusinessException(
+                    ErrorCode.LEAGUE_NOT_FOUND,
+                    String.format("%s 에서 리그 정보를 제공하지 않았습니다.", provider));
         }
 
         return leagueService.getOrCreateLeague(provider, internalSportId, betsLeague.getId(), betsLeague.getName(), betsLeague.getCc());
@@ -77,7 +80,14 @@ public class MatchEventSyncService {
         return teamService.getOrCreateTeam(provider, internalSportId, betsTeam.getId(), betsTeam.getName(), betsTeam.getCc(), imageUrl);
     }
 
-    private void saveMatch(ApiProvider provider, BetsEventResponse.Event event, Long internalSportId, Long internalLeagueId, Long internalHomeId, Long internalAwayId) {
+    private void saveMatch(
+            ApiProvider provider,
+            BetsEventResponse.Event event,
+            Long internalSportId,
+            League league,
+            Team homeTeam,
+            Team awayTeam) {
+
         if (event.getLeague() == null || event.getHome() == null || event.getAway() == null) {
             log.warn("경기 저장 스킵 - 필수 정보 누락 (league/home/away) eventId: {}", event.getId());
             return;
@@ -88,12 +98,13 @@ public class MatchEventSyncService {
                         .provider(provider)
                         .apiMatchId(event.getId())
                         .bet365Id(event.getBet365Id())
+                        .teamDisplayOrder(matchTeamDisplayOrderPolicy.decide(league))
                         .build());
 
         match.updateSportId(internalSportId);
-        match.updateLeagueId(internalLeagueId);
-        match.updateHomeId(internalHomeId);
-        match.updateAwayId(internalAwayId);
+        match.updateLeagueId(league.getId());
+        match.updateHomeId(homeTeam.getId());
+        match.updateAwayId(awayTeam.getId());
         match.updateStatus(MatchStatus.fromCode(event.getTimeStatus()));
 
         if (event.getTime() != null) {

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchTeamDisplayOrderPolicy.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchTeamDisplayOrderPolicy.java
@@ -1,0 +1,25 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class MatchTeamDisplayOrderPolicy {
+
+    /**
+     * Match 의 TeamDisplayOrder 값을 결정하며 아래와 같은 규칙을 따른다.
+     * 1. 기본적으로 모든 Match 의 TeamDisplayOrder 는 HOME-AWAY
+     * 2. 만약 리그에 할당된 TeamDisplayOrder 가 있다면 해당 리그에 속한 모든 경기는 리그의 TeamDisplayOrder 를 따른다.
+     */
+    public TeamDisplayOrder decide(League league) {
+        if (league != null && league.hasTeamDisplayOrder()) {
+            return league.getTeamDisplayOrder();
+        }
+
+        return TeamDisplayOrder.HOME_AWAY;
+    }
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminServiceTeamDisplayOrderTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchAdminServiceTeamDisplayOrderTest.java
@@ -1,0 +1,140 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import static com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueRepository;
+import com.scorenow.scorenow_api.domain.match.dto.request.MatchCreateRequest;
+import com.scorenow.scorenow_api.domain.match.dto.request.MatchUpdateRequest;
+import com.scorenow.scorenow_api.domain.match.dto.response.MatchListResponse;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.mapper.MatchMapper;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import com.scorenow.scorenow_api.domain.sport.repository.SportRepository;
+import com.scorenow.scorenow_api.domain.team.repository.TeamRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MatchAdminServiceTeamDisplayOrderTest {
+
+    @Mock
+    private MatchRepository matchRepository;
+
+    @Mock
+    private LeagueRepository leagueRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private SportRepository sportRepository;
+
+    @Spy
+    private MatchMapper matchMapper = new MatchMapper();
+
+    @Spy
+    private MatchTeamDisplayOrderPolicy matchTeamDisplayOrderPolicy = new MatchTeamDisplayOrderPolicy();
+
+    @InjectMocks
+    private MatchAdminService matchAdminService;
+
+    @Test
+    void 수동_경기_생성시_리그의_표시_정책을_Match에_저장한다() {
+        MatchCreateRequest request = createRequest();
+        League league = League.builder()
+                .id(request.getLeagueId())
+                .sportId(request.getSportId())
+                .eName("Premier League")
+                .teamDisplayOrder(AWAY_HOME)
+                .build();
+
+        givenValidCreateRequest(request);
+        given(leagueRepository.findById(request.getLeagueId())).willReturn(Optional.of(league));
+        given(matchRepository.save(any(Match.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(matchRepository.findByIdWithRelations(any())).willReturn(Optional.empty());
+
+        MatchListResponse response = matchAdminService.createMatch(request);
+
+        ArgumentCaptor<Match> matchCaptor = ArgumentCaptor.forClass(Match.class);
+        then(matchRepository).should().save(matchCaptor.capture());
+
+        assertThat(matchCaptor.getValue().getTeamDisplayOrder()).isEqualTo(AWAY_HOME);
+        assertThat(response.getTeamDisplayOrder()).isEqualTo(List.of("AWAY","HOME"));
+    }
+
+    @Test
+    void 수동_경기_생성시_리그의_표시_정책이_없으면_HOME_AWAY를_Match에_저장한다() {
+        MatchCreateRequest request = createRequest();
+        League league = League.builder()
+                .id(request.getLeagueId())
+                .sportId(request.getSportId())
+                .eName("Premier League")
+                .build();
+
+        givenValidCreateRequest(request);
+        given(leagueRepository.findById(request.getLeagueId())).willReturn(Optional.of(league));
+        given(matchRepository.save(any(Match.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(matchRepository.findByIdWithRelations(any())).willReturn(Optional.empty());
+
+        MatchListResponse response = matchAdminService.createMatch(request);
+
+        ArgumentCaptor<Match> matchCaptor = ArgumentCaptor.forClass(Match.class);
+        then(matchRepository).should().save(matchCaptor.capture());
+
+        assertThat(matchCaptor.getValue().getTeamDisplayOrder()).isEqualTo(HOME_AWAY);
+        assertThat(response.getTeamDisplayOrder()).isEqualTo(List.of("HOME","AWAY"));
+    }
+
+    @Test
+    void 경기_수정시_요청한_표시_정책으로_Match를_변경한다() {
+        Long matchId = 1L;
+        Match match = Match.builder()
+                .id(matchId)
+                .sportId(1L)
+                .leagueId(1L)
+                .homeId(10L)
+                .awayId(20L)
+                .teamDisplayOrder(HOME_AWAY)
+                .build();
+
+        MatchUpdateRequest request = new MatchUpdateRequest();
+        request.setTeamDisplayOrder(AWAY_HOME);
+
+        given(matchRepository.findById(matchId)).willReturn(Optional.of(match));
+
+        matchAdminService.updateMatch(matchId, request);
+
+        assertThat(match.getTeamDisplayOrder()).isEqualTo(AWAY_HOME);
+    }
+
+    private MatchCreateRequest createRequest() {
+        MatchCreateRequest request = new MatchCreateRequest();
+        request.setSportId(1L);
+        request.setLeagueId(2L);
+        request.setHomeId(10L);
+        request.setAwayId(20L);
+        request.setStartAt(LocalDateTime.of(2026, 1, 1, 19, 0));
+        return request;
+    }
+
+    private void givenValidCreateRequest(MatchCreateRequest request) {
+        given(leagueRepository.existsById(request.getLeagueId())).willReturn(true);
+        given(teamRepository.existsById(request.getHomeId())).willReturn(true);
+        given(teamRepository.existsById(request.getAwayId())).willReturn(true);
+        given(sportRepository.existsById(request.getSportId())).willReturn(true);
+    }
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchTeamDisplayOrderPolicyTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchTeamDisplayOrderPolicyTest.java
@@ -1,0 +1,47 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
+import com.scorenow.scorenow_api.domain.league.entity.League;
+
+class MatchTeamDisplayOrderPolicyTest {
+
+    private final MatchTeamDisplayOrderPolicy policy = new MatchTeamDisplayOrderPolicy();
+
+    @Test
+    void 리그가_null이면_시스템_기본값인_HOME_AWAY를_반환한다() {
+        TeamDisplayOrder result = policy.decide(null);
+
+        assertThat(result).isEqualTo(TeamDisplayOrder.HOME_AWAY);
+    }
+
+    @Test
+    void 리그에_표시_정책이_없으면_시스템_기본값인_HOME_AWAY를_반환한다() {
+        League league = League.builder()
+                .id(1L)
+                .sportId(1L)
+                .eName("Premier League")
+                .build();
+
+        TeamDisplayOrder result = policy.decide(league);
+
+        assertThat(result).isEqualTo(TeamDisplayOrder.HOME_AWAY);
+    }
+
+    @Test
+    void 리그에_표시_정책이_있으면_리그의_표시_정책을_반환한다() {
+        League league = League.builder()
+                .id(1L)
+                .sportId(1L)
+                .eName("Premier League")
+                .teamDisplayOrder(TeamDisplayOrder.AWAY_HOME)
+                .build();
+
+        TeamDisplayOrder result = policy.decide(league);
+
+        assertThat(result).isEqualTo(TeamDisplayOrder.AWAY_HOME);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number
- #74 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
- 각 경기의 홈-어웨이 표기 정책을 관리하는 로직을 추가하였습니다.
- 표기 정책이 적용되는 방식은 아래와 같습니다.
   1. 기본적으로 `HOME_AWAY` 방식으로 저장
   2. 만약 경기가 속한 리그의 표기 정책이 따로 지정되어 있다면, 해당 방식을 따르게 됨.

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- TeamDisplayOrder 를 통해 표기 정책 종류를 관리합니다.
- 내부적으로는 Enum 으로 관리되나, 클라이언트에게 내려주는 응답 형식은 문자열 리스트 입니다.
   - 클라이언트 응답값 예시 : `teamDisplayOrder : ["AWAY","HOME"]`
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
