### PR TITLE
feat: 경기 리스트 API 개발 (앱 전용)

### DIFF
--- a/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAppApiDocs.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAppApiDocs.java
@@ -1,0 +1,31 @@
+package com.scorenow.scorenow_api.domain.match.controller;
+
+import com.scorenow.scorenow_api.domain.match.dto.response.MatchAppResponse;
+import com.scorenow.scorenow_api.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "Match App API", description = "앱 경기 목록 조회 API")
+public interface MatchAppApiDocs {
+
+    @Operation(
+            summary = "앱 경기 목록 조회",
+            description = """
+                    앱에서 사용하는 경기 목록을 조회합니다.
+                    날짜, 종목, 리그 조건으로 필터링할 수 있으며 정렬 순서는 진행중 > 경기 예정 > 경기 종료입니다.
+                    경기 진행 시간과 현재 중계 멘트는 MatchDetailDocument 정보를 조합하여 반환합니다.
+                    """
+    )
+    ApiResponse<List<MatchAppResponse>> getMatches(
+            @Parameter(description = "조회 날짜. yyyyMMdd 형식입니다. 값이 없으면 서버 기준 오늘 날짜로 조회합니다.", example = "20260605")
+            LocalDate date,
+            @Parameter(description = "종목 ID", example = "1")
+            Long sportId,
+            @Parameter(description = "리그 ID", example = "2")
+            Long leagueId
+    );
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAppController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAppController.java
@@ -1,0 +1,32 @@
+package com.scorenow.scorenow_api.domain.match.controller;
+
+import com.scorenow.scorenow_api.domain.match.dto.response.MatchAppResponse;
+import com.scorenow.scorenow_api.domain.match.service.MatchAppQueryService;
+import com.scorenow.scorenow_api.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/app/matches")
+@RequiredArgsConstructor
+public class MatchAppController {
+
+    private final MatchAppQueryService matchAppQueryService;
+
+    @GetMapping
+    public ApiResponse<List<MatchAppResponse>> getMatches(
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
+            @RequestParam(required = false) Long sportId,
+            @RequestParam(required = false) Long leagueId
+    ) {
+        List<MatchAppResponse> matches = matchAppQueryService.getMatches(date, sportId, leagueId);
+        return ApiResponse.success(matches);
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAppController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/controller/MatchAppController.java
@@ -16,7 +16,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/app/matches")
 @RequiredArgsConstructor
-public class MatchAppController {
+public class MatchAppController implements MatchAppApiDocs {
 
     private final MatchAppQueryService matchAppQueryService;
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchAppResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchAppResponse.java
@@ -9,6 +9,7 @@ import com.scorenow.scorenow_api.domain.match.entity.MatchPeriod;
 import com.scorenow.scorenow_api.domain.match.entity.MatchResult;
 import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
 import com.scorenow.scorenow_api.domain.team.entity.Team;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.util.StringUtils;
@@ -21,31 +22,59 @@ import static com.scorenow.scorenow_api.domain.match.entity.MatchResult.*;
 
 @Getter
 @Builder
+@Schema(description = "앱 경기 목록 응답")
 public class MatchAppResponse {
+    @Schema(description = "경기 ID", example = "1001")
     private Long id;
 
+    @Schema(description = "경기 날짜", example = "2026-06-05")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
+    @Schema(description = "리그 ID", example = "2")
     private Long leagueId;
+
+    @Schema(description = "리그 이름", example = "프리미어리그")
     private String leagueName;
 
+    @Schema(description = "홈팀 정보")
     private AppTeamResponse homeTeam;
+
+    @Schema(description = "어웨이팀 정보")
     private AppTeamResponse awayTeam;
+
+    @Schema(description = "홈팀 점수", example = "1")
     private Integer homeScore;
+
+    @Schema(description = "어웨이팀 점수", example = "0")
     private Integer awayScore;
 
+    @Schema(description = "경기 상태 코드", example = "NOT_STARTED, IN_PLAY, ENDED")
     private String statusCode;
+
+    @Schema(description = "경기 상태명", example = "경기전, 진행중, 종료")
     private String statusName;
+
+    @Schema(description = "현재 앱에 보여줄 중계 멘트", example = "홈팀이 선제골 이후 흐름을 잡습니다.")
     private String currentCommentary;
+
+    @Schema(description = "경기 시간 정보")
     private AppMatchTimeInfoResponse timeInfo;
+
+    @Schema(description = "팀 표시 순서", example = "[\"HOME\", \"AWAY\"]")
     private List<String> teamDisplayOrder;
 
     @Getter
     @Builder
+    @Schema(description = "앱 경기 팀 응답")
     public static class AppTeamResponse {
+        @Schema(description = "팀 ID", example = "10")
         private Long id;
+
+        @Schema(description = "팀 이름", example = "대한민국")
         private String name;
+
+        @Schema(description = "팀 이미지 URL", example = "https://assets.b365api.com/images/team/m/676363.png")
         private String imageUrl;
 
         public static AppTeamResponse from(Long teamId, Team team) {
@@ -59,20 +88,34 @@ public class MatchAppResponse {
 
     @Getter
     @Builder
+    @Schema(description = "앱 경기 시간 정보 응답")
     public static class AppMatchTimeInfoResponse {
-        private String type;
-
+        @Schema(description = "경기 예정 시작 시간.", example = "2026-06-05T20:00:00")
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime startAt;
 
+        @Schema(description = "경기 경과 시간 분", example = "27")
         private Integer elapsedMinutes;
+
+        @Schema(description = "경기 경과 시간 초", example = "14")
         private Integer elapsedSeconds;
+
+        @Schema(description = "경기 구간 코드", example = "FIRST_HALF")
         private String periodCode;
+
+        @Schema(description = "경기 구간명", example = "전반전")
         private String periodName;
+
+        @Schema(description = "타이머 진행 여부", example = "true")
         private Boolean running;
 
+        @Schema(description = "경기 결과. HOME_WIN, AWAY_WIN, DRAW, UNKNOWN 중 하나입니다.", example = "HOME_WIN")
         private String result;
+
+        @Schema(description = "승리팀 ID. 무승부나 결과 미확정이면 null입니다.", example = "10")
         private Long winnerTeamId;
+
+        @Schema(description = "승리팀 이름. 무승부나 결과 미확정이면 null입니다.", example = "대한민국")
         private String winnerTeamName;
 
         public static AppMatchTimeInfoResponse from(Match match, MatchDetailDocument detail, Integer homeScore, Integer awayScore) {
@@ -98,7 +141,6 @@ public class MatchAppResponse {
             MatchPeriod period = matchClock != null ? matchClock.getPeriod() : null;
 
             return AppMatchTimeInfoResponse.builder()
-                    .type(MatchStatus.IN_PLAY.name())
                     .elapsedMinutes(matchClock != null ? matchClock.getElapsedMinutes() : null)
                     .elapsedSeconds(matchClock != null ? matchClock.getElapsedSeconds() : null)
                     .periodCode(period != null ? period.name() : null)
@@ -109,7 +151,6 @@ public class MatchAppResponse {
 
         private static AppMatchTimeInfoResponse toNotStartedTimeInfo(Match match) {
             return AppMatchTimeInfoResponse.builder()
-                    .type(MatchStatus.NOT_STARTED.name())
                     .startAt(match.getStartAt())
                     .build();
         }
@@ -118,7 +159,6 @@ public class MatchAppResponse {
             MatchResult matchResult = fromScore(homeScore, awayScore);
 
             return AppMatchTimeInfoResponse.builder()
-                    .type("ENDED")
                     .result(matchResult.name())
                     .winnerTeamId(resolveWinnerTeamId(match, matchResult))
                     .winnerTeamName(resolveWinnerTeamName(match, matchResult))

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchAppResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchAppResponse.java
@@ -148,23 +148,6 @@ public class MatchAppResponse {
 
             return null;
         }
-
-
-        private static String resolveResult(Integer homeScore, Integer awayScore) {
-            if (homeScore == null || awayScore == null) {
-                return "UNKNOWN";
-            }
-
-            if (homeScore > awayScore) {
-                return "HOME_WIN";
-            }
-
-            if (homeScore < awayScore) {
-                return "AWAY_WIN";
-            }
-
-            return "DRAW";
-        }
     }
 
     public static MatchAppResponse from(Match match, MatchDetailDocument detail) {

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchAppResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/dto/response/MatchAppResponse.java
@@ -1,0 +1,245 @@
+package com.scorenow.scorenow_api.domain.match.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.match.document.MatchDetailDocument;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.entity.MatchPeriod;
+import com.scorenow.scorenow_api.domain.match.entity.MatchResult;
+import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+import com.scorenow.scorenow_api.domain.team.entity.Team;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.scorenow.scorenow_api.domain.match.entity.MatchResult.*;
+
+@Getter
+@Builder
+public class MatchAppResponse {
+    private Long id;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    private Long leagueId;
+    private String leagueName;
+
+    private AppTeamResponse homeTeam;
+    private AppTeamResponse awayTeam;
+    private Integer homeScore;
+    private Integer awayScore;
+
+    private String statusCode;
+    private String statusName;
+    private String currentCommentary;
+    private AppMatchTimeInfoResponse timeInfo;
+    private List<String> teamDisplayOrder;
+
+    @Getter
+    @Builder
+    public static class AppTeamResponse {
+        private Long id;
+        private String name;
+        private String imageUrl;
+
+        public static AppTeamResponse from(Long teamId, Team team) {
+            return AppTeamResponse.builder()
+                    .id(teamId)
+                    .name(team.getKName())
+                    .imageUrl(team.getImageUrl())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class AppMatchTimeInfoResponse {
+        private String type;
+
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime startAt;
+
+        private Integer elapsedMinutes;
+        private Integer elapsedSeconds;
+        private String periodCode;
+        private String periodName;
+        private Boolean running;
+
+        private String result;
+        private Long winnerTeamId;
+        private String winnerTeamName;
+
+        public static AppMatchTimeInfoResponse from(Match match, MatchDetailDocument detail, Integer homeScore, Integer awayScore) {
+            MatchStatus status = match.getStatusCode();
+
+            if (status == MatchStatus.IN_PLAY) {
+                return toInPlayTimeInfo(detail);
+            }
+
+            if (status == MatchStatus.NOT_STARTED) {
+                return toNotStartedTimeInfo(match);
+            }
+
+            if (status == MatchStatus.ENDED) {
+                return toResultTimeInfo(match, homeScore, awayScore);
+            }
+
+            return AppMatchTimeInfoResponse.builder().build();
+        }
+
+        private static AppMatchTimeInfoResponse toInPlayTimeInfo(MatchDetailDocument detail) {
+            MatchDetailDocument.MatchClock matchClock = detail != null ? detail.getMatchClock() : null;
+            MatchPeriod period = matchClock != null ? matchClock.getPeriod() : null;
+
+            return AppMatchTimeInfoResponse.builder()
+                    .type(MatchStatus.IN_PLAY.name())
+                    .elapsedMinutes(matchClock != null ? matchClock.getElapsedMinutes() : null)
+                    .elapsedSeconds(matchClock != null ? matchClock.getElapsedSeconds() : null)
+                    .periodCode(period != null ? period.name() : null)
+                    .periodName(period != null ? period.getDescription() : null)
+                    .running(matchClock != null ? matchClock.getRunning() : null)
+                    .build();
+        }
+
+        private static AppMatchTimeInfoResponse toNotStartedTimeInfo(Match match) {
+            return AppMatchTimeInfoResponse.builder()
+                    .type(MatchStatus.NOT_STARTED.name())
+                    .startAt(match.getStartAt())
+                    .build();
+        }
+
+        private static AppMatchTimeInfoResponse toResultTimeInfo(Match match, Integer homeScore, Integer awayScore) {
+            MatchResult matchResult = fromScore(homeScore, awayScore);
+
+            return AppMatchTimeInfoResponse.builder()
+                    .type("ENDED")
+                    .result(matchResult.name())
+                    .winnerTeamId(resolveWinnerTeamId(match, matchResult))
+                    .winnerTeamName(resolveWinnerTeamName(match, matchResult))
+                    .build();
+        }
+
+        private static Long resolveWinnerTeamId(Match match, MatchResult matchResult) {
+            if (matchResult == HOME_WIN) {
+                return match.getHomeId();
+            }
+
+            if (matchResult == AWAY_WIN) {
+                return match.getAwayId();
+            }
+
+            return null;
+        }
+
+        private static String resolveWinnerTeamName(Match match, MatchResult matchResult) {
+            if (matchResult == HOME_WIN) {
+                return resolveTeamName(match.getHomeTeam());
+            }
+
+            if (matchResult == AWAY_WIN) {
+                return resolveTeamName(match.getAwayTeam());
+            }
+
+            return null;
+        }
+
+
+        private static String resolveResult(Integer homeScore, Integer awayScore) {
+            if (homeScore == null || awayScore == null) {
+                return "UNKNOWN";
+            }
+
+            if (homeScore > awayScore) {
+                return "HOME_WIN";
+            }
+
+            if (homeScore < awayScore) {
+                return "AWAY_WIN";
+            }
+
+            return "DRAW";
+        }
+    }
+
+    public static MatchAppResponse from(Match match, MatchDetailDocument detail) {
+        Integer homeScore = resolveHomeScore(match, detail);
+        Integer awayScore = resolveAwayScore(match, detail);
+
+        return MatchAppResponse.builder()
+                .id(match.getId())
+                .date(match.getStartAt().toLocalDate())
+                .leagueId(match.getLeagueId())
+                .leagueName(resolveLeagueName(match.getLeague()))
+                .homeTeam(AppTeamResponse.from(match.getHomeId(), match.getHomeTeam()))
+                .awayTeam(AppTeamResponse.from(match.getAwayId(), match.getAwayTeam()))
+                .homeScore(homeScore)
+                .awayScore(awayScore)
+                .statusCode(match.getStatusCode().name())
+                .statusName(match.getStatusCode().getDescription())
+                .currentCommentary(detail != null ? detail.getCurrentCommentary() : null)
+                .timeInfo(AppMatchTimeInfoResponse.from(match, detail, homeScore, awayScore))
+                .teamDisplayOrder(resolveTeamDisplayOrder(match))
+                .build();
+    }
+
+    private static Integer resolveHomeScore(Match match, MatchDetailDocument detail) {
+        if (detail != null && detail.getHomeScore() != null) {
+            return detail.getHomeScore();
+        }
+
+        return match.getHomeScore();
+    }
+
+    private static Integer resolveAwayScore(Match match, MatchDetailDocument detail) {
+        if (detail != null && detail.getAwayScore() != null) {
+            return detail.getAwayScore();
+        }
+
+        return match.getAwayScore();
+    }
+
+    private static String resolveLeagueName(League league) {
+        if (league == null) {
+            return "";
+        }
+
+        if (StringUtils.hasText(league.getKName())) {
+            return league.getKName();
+        }
+
+        if (StringUtils.hasText(league.getEName())) {
+            return league.getEName();
+        }
+
+        return league.getSName();
+    }
+
+    private static String resolveTeamName(Team team) {
+        if (team == null) {
+            return "";
+        }
+
+        if (StringUtils.hasText(team.getKName())) {
+            return team.getKName();
+        }
+
+        if (StringUtils.hasText(team.getEName())) {
+            return team.getEName();
+        }
+
+        return team.getSName();
+    }
+
+    private static List<String> resolveTeamDisplayOrder(Match match) {
+        return match.getTeamDisplayOrder() != null
+                ? match.getTeamDisplayOrder().toDisplaySides()
+                : TeamDisplayOrder.HOME_AWAY.toDisplaySides();
+    }
+
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchPeriod.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchPeriod.java
@@ -5,7 +5,10 @@ import lombok.Getter;
 @Getter
 public enum MatchPeriod {
     FIRST_HALF(0, "전반전"),
-    SECOND_HALF(1, "후반전");
+    SECOND_HALF(1, "후반전"),
+    EXTRA_FIRST_HALF(2, "연장전 전반"),
+    EXTRA_SECOND_HALF(3, "연장전 후반"),
+    PENALTY_SHOOTOUT(4, "승부차기");
 
     private final Integer code;
     private final String description;

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchResult.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchResult.java
@@ -1,0 +1,21 @@
+package com.scorenow.scorenow_api.domain.match.entity;
+
+public enum MatchResult {
+    HOME_WIN,
+    AWAY_WIN,
+    DRAW,
+    UNKNOWN;
+
+    public static MatchResult fromScore(Integer homeScore, Integer awayScore) {
+        if (homeScore == null || awayScore == null) {
+            return UNKNOWN;
+        }
+
+        if (homeScore == awayScore) {
+            return DRAW;
+        }
+
+        return homeScore > awayScore ? HOME_WIN : AWAY_WIN;
+    }
+
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchResult.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/entity/MatchResult.java
@@ -11,7 +11,7 @@ public enum MatchResult {
             return UNKNOWN;
         }
 
-        if (homeScore == awayScore) {
+        if (homeScore.equals(awayScore)) {
             return DRAW;
         }
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/MatchDetailRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/MatchDetailRepository.java
@@ -2,14 +2,19 @@ package com.scorenow.scorenow_api.domain.match.repository;
 
 import com.scorenow.scorenow_api.domain.match.document.MatchDetailDocument;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MatchDetailRepository {
     Optional<MatchDetailDocument> findById(Long matchId);
 
+    List<MatchDetailDocument> findAllById(List<Long> matchIds);
+
     MatchDetailDocument save(MatchDetailDocument detail);
 
     long updateCurrentCommentary(Long matchId, String content, String commentaryId);
+
+    void upsertCurrentCommentary(Long matchId, String content, String commentaryId);
 
     void upsertMatchDetail(MatchDetailDocument matchDetailDocument);
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/MatchDetailRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/MatchDetailRepository.java
@@ -12,8 +12,6 @@ public interface MatchDetailRepository {
 
     MatchDetailDocument save(MatchDetailDocument detail);
 
-    long updateCurrentCommentary(Long matchId, String content, String commentaryId);
-
     void upsertCurrentCommentary(Long matchId, String content, String commentaryId);
 
     void upsertMatchDetail(MatchDetailDocument matchDetailDocument);

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/jpa/MatchRepository.java
@@ -82,4 +82,36 @@ public interface MatchRepository extends JpaRepository<Match, Long>, MatchReposi
     void updateStatusBulk(List<Long> matchIds, MatchStatus status);
 
     List<Match> findByStatusCodeAndIsManualFalse(MatchStatus matchStatus);
+
+    @Query("""
+            select distinct m
+            from Match m
+            left join fetch m.league
+            left join fetch m.homeTeam
+            left join fetch m.awayTeam
+            where m.isActive = true
+              and m.startAt >= :startAt
+              and m.startAt < :endAt
+              and (:sportId is null or m.sportId = :sportId)
+              and (:leagueId is null or m.leagueId = :leagueId)
+              and m.statusCode in :statuses
+            order by
+              case
+                when m.statusCode = :inPlay then 0
+                when m.statusCode = :notStarted then 1
+                when m.statusCode = :ended then 2
+                else 3
+              end asc,
+              m.startAt asc
+            """)
+    List<Match> findAppMatches(
+            @Param("startAt") LocalDateTime startAt,
+            @Param("endAt") LocalDateTime endAt,
+            @Param("sportId") Long sportId,
+            @Param("leagueId") Long leagueId,
+            @Param("statuses") List<MatchStatus> statuses,
+            @Param("inPlay") MatchStatus inPlay,
+            @Param("notStarted") MatchStatus notStarted,
+            @Param("ended") MatchStatus ended
+    );
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/mongo/MatchCommentaryMongoRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/mongo/MatchCommentaryMongoRepository.java
@@ -2,7 +2,11 @@ package com.scorenow.scorenow_api.domain.match.repository.mongo;
 
 import com.scorenow.scorenow_api.domain.match.document.MatchCommentaryDocument;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
+import java.util.List;
 
 public interface MatchCommentaryMongoRepository extends MongoRepository<MatchCommentaryDocument, String> {
-}
+    @Query(value = "{ 'matchId' : ?0, 'visible' : true }",
+            sort = "{ 'created_at' :  -1 }")
+    List<MatchCommentaryDocument> findVisibleCommentaries(Long matchId);}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/mongo/MatchCommentaryMongoRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/mongo/MatchCommentaryMongoRepository.java
@@ -2,13 +2,7 @@ package com.scorenow.scorenow_api.domain.match.repository.mongo;
 
 import com.scorenow.scorenow_api.domain.match.document.MatchCommentaryDocument;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
-
-import java.util.List;
 
 
 public interface MatchCommentaryMongoRepository extends MongoRepository<MatchCommentaryDocument, String> {
-    @Query(value = "{ 'matchId' : ?0, 'visible' : true }",
-            sort = "{ 'created_at' :  -1 }")
-    List<MatchCommentaryDocument> findVisibleCommentaries(Long matchId);
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/mongo/MatchDetailRepositoryImpl.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/mongo/MatchDetailRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.scorenow.scorenow_api.domain.match.document.MatchDetailDocument.*;
@@ -30,8 +31,24 @@ public class MatchDetailRepositoryImpl implements MatchDetailRepository {
     }
 
     @Override
+    public List<MatchDetailDocument> findAllById(List<Long> matchIds) {
+        return mongoRepository.findAllById(matchIds);
+    }
+
+    @Override
     public long updateCurrentCommentary(Long matchId, String content, String commentaryId) {
         return mongoRepository.updateCurrentCommentary(matchId, content, commentaryId);
+    }
+
+    @Override
+    public void upsertCurrentCommentary(Long matchId, String content, String commentaryId) {
+        Query query = new Query(Criteria.where("_id").is(matchId));
+        Update update = new Update()
+                .set("currentCommentary", content)
+                .set("currentCommentaryId", commentaryId)
+                .setOnInsert("_id", matchId);
+
+        mongoTemplate.upsert(query, update, MatchDetailDocument.class);
     }
 
     @Override

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/repository/mongo/MatchDetailRepositoryImpl.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/repository/mongo/MatchDetailRepositoryImpl.java
@@ -36,11 +36,6 @@ public class MatchDetailRepositoryImpl implements MatchDetailRepository {
     }
 
     @Override
-    public long updateCurrentCommentary(Long matchId, String content, String commentaryId) {
-        return mongoRepository.updateCurrentCommentary(matchId, content, commentaryId);
-    }
-
-    @Override
     public void upsertCurrentCommentary(Long matchId, String content, String commentaryId) {
         Query query = new Query(Criteria.where("_id").is(matchId));
         Update update = new Update()

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchDetailScheduler.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchDetailScheduler.java
@@ -20,7 +20,8 @@ public class MatchDetailScheduler {
      * 작업 내용 : 현재 진행중인 경기의 세부 정보를 동기화 한다. (세부 정보 : 경기 중 발생한 이벤트 기반으로 수치화된 스텟 정보들)
      * 작업 주기 : 1분 마다
      */
-    @Scheduled(fixedDelay = 60000)  // TODO: 작업 주기는 동적으로 관리될 필요가 있을 듯 하고, 추가적으로 API 리밋도 같이 고려하는 주기로 설정해야 한다.
+    @Scheduled(fixedDelay = 60000, zone = "Asia/Seoul")
+    // TODO: 작업 주기는 동적으로 관리될 필요가 있을 듯 하고, 추가적으로 API 리밋도 같이 고려하는 주기로 설정해야 한다.
     public void syncInplayMatchDetails() {
         log.info("📅 INPLAY 경기 세부 정보 동기화 시작");
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchLineupSyncScheduler.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchLineupSyncScheduler.java
@@ -34,7 +34,7 @@ public class MatchLineupSyncScheduler {
 	@Value("${scorenow.inplay.worker.lineup.lockTtlMs:10000}")
 	private long lockTtlMs;
 
-	@Scheduled(fixedDelayString = "${scorenow.inplay.worker.lineup.fixedDelayMs:10000}")
+	@Scheduled(fixedDelayString = "${scorenow.inplay.worker.lineup.fixedDelayMs:10000}", zone = "Asia/Seoul")
 	public void run() {
 
 		for (int i = 0; i < initBatchSize; i++) {

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchSyncScheduler.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchSyncScheduler.java
@@ -36,7 +36,7 @@ public class MatchSyncScheduler {
      * 매일 2회 배치 실행(4시, 16시)
      * 테스트 시 임시 사용: @Scheduled(initialDelay = 10000, fixedRate = 1000000)
      */
-    @Scheduled(cron = "0 0 4,16 * * *")
+    @Scheduled(cron = "0 0 4,16 * * *", zone = "Asia/Seoul")
     public void runMatchSyncJob() {
         log.info("=== Match Sync Batch Job 시작 ===");
 
@@ -56,7 +56,7 @@ public class MatchSyncScheduler {
     /**
      * Ended - 10분마다 (오늘 경기만, 종료 후 30분 내 반영)
      */
-    @Scheduled(fixedDelay = 600000)
+    @Scheduled(fixedDelay = 600000, zone = "Asia/Seoul")
     public void syncEndedMatches() {
         log.info("=== [ENDED] 종료 경기 동기화 ===");
 
@@ -72,7 +72,7 @@ public class MatchSyncScheduler {
      * 작업 내용 : 현재 시간 기준 향후 1시간 이내 시작 예정인 경기들을 조회 후 캐싱
      * 작업 주기 : 매 시 정각과 30분
      */
-    @Scheduled(cron = "0 0/30 * * * *")
+    @Scheduled(cron = "0 0/30 * * * *", zone = "Asia/Seoul")
     public void loadInplayCandidatesToCache() {
         log.info("📅 INPLAY 예정 경기 캐싱 시작");
 
@@ -87,7 +87,7 @@ public class MatchSyncScheduler {
      * 작업 내용 : Redis ZSet 에 저장한 1시간 이내 시작 예정인 경기 중, 경기 시작한 건에 대해서 외부 API 를 호출을 통한 동기화 작업을 진행
      * 작업 주기 : 매 분 (1분 마다)
      */
-    @Scheduled(cron = "0 * * * * *")
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void syncInplayMatches() {
         log.info("📅 INPLAY 경기 동기화 시작");
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAppQueryService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchAppQueryService.java
@@ -1,0 +1,70 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import com.scorenow.scorenow_api.domain.match.document.MatchDetailDocument;
+import com.scorenow.scorenow_api.domain.match.dto.response.MatchAppResponse;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+import com.scorenow.scorenow_api.domain.match.repository.MatchDetailRepository;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toMap;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MatchAppQueryService {
+
+    private final MatchRepository matchRepository;
+    private final MatchDetailRepository matchDetailRepository;
+
+    public List<MatchAppResponse> getMatches(LocalDate date, Long sportId, Long leagueId) {
+        LocalDate targetDate = date != null ? date : LocalDate.now();
+        LocalDateTime startAt = targetDate.atStartOfDay();
+        LocalDateTime endAt = targetDate.plusDays(1).atStartOfDay();
+
+        // 1. 경기 목록을 조회한다.
+        List<Match> matches = matchRepository.findAppMatches(
+                startAt,
+                endAt,
+                sportId,
+                leagueId,
+                List.of(MatchStatus.IN_PLAY, MatchStatus.NOT_STARTED, MatchStatus.ENDED),
+                MatchStatus.IN_PLAY,
+                MatchStatus.NOT_STARTED,
+                MatchStatus.ENDED
+        );
+
+        if (matches.isEmpty()) {
+            log.info("해당 날짜 {} 에 대하여 조회되는 경기가 없습니다. sportId={}, leagueId={}", date, sportId, leagueId);
+            return List.of();
+        }
+
+        // 2. 경기 목록 조회 결과 기반으로 경기 상세 정보를 조회한다.
+        List<Long> matchIds = matches.stream()
+                .map(Match::getId)
+                .toList();
+
+        Map<Long, MatchDetailDocument> detailMap = matchDetailRepository.findAllById(matchIds).stream()
+                .collect(toMap(
+                        MatchDetailDocument::getId,
+                        Function.identity(),
+                        (first, second) -> first));
+
+        // 3. (1)과 (2)에서 얻어 온 결과값을 활용하여 응답을 만든 후 반환한다.
+        return matches.stream()
+                .map(match -> MatchAppResponse.from(match, detailMap.get(match.getId())))
+                .toList();
+    }
+
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchCommentaryService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchCommentaryService.java
@@ -4,6 +4,7 @@ package com.scorenow.scorenow_api.domain.match.service;
 import com.scorenow.scorenow_api.domain.match.document.MatchCommentaryDocument;
 import com.scorenow.scorenow_api.domain.match.repository.MatchCommentaryRepository;
 import com.scorenow.scorenow_api.domain.match.repository.MatchDetailRepository;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
 import com.scorenow.scorenow_api.global.exception.BusinessException;
 import com.scorenow.scorenow_api.global.exception.ErrorCode;
 import com.scorenow.scorenow_api.global.infra.storage.FileStorage;
@@ -13,18 +14,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MatchCommentaryService {
+
     private final MatchCommentaryRepository commentaryRepository;
     private final MatchDetailRepository matchDetailRepository;
-    private final FileStorage fileStorage;
+    private final MatchRepository matchRepository;
 
-    /**
-     * TODO: matchId 가 유효한지 먼저 검증하는 로직을 추가하는 것도 괜찮을 듯? 기능 자체는 잘 돌아감.
-     */
+    private final FileStorage fileStorage;
 
     /**
      * 중계 멘트 저장 <br>
@@ -37,7 +36,10 @@ public class MatchCommentaryService {
             imageUrl = fileStorage.uploadFile(file);
         }
 
-        // 1. mongoDB 에 저장할 Document 인스턴스 생성
+        // 1. matchId 기반으로 존재하는 경기인지 먼저 확인
+        validateMatchExists(matchId);
+
+        // 2. mongoDB 에 저장할 MatchCommentaryDocument 인스턴스 생성 후 저장
         MatchCommentaryDocument commentary = MatchCommentaryDocument.builder()
                 .matchId(matchId)
                 .currentMatchTime(minute)
@@ -46,15 +48,10 @@ public class MatchCommentaryService {
                 .visible(recordEnabled)
                 .build();
 
-        // 2. MatchCommentary Document 저장
         MatchCommentaryDocument savedCommentary = commentaryRepository.save(commentary);
 
-        // 3. MatchDetail 에서 관리되는 현재 중계 멘트 업데이트
-        long updatedCount = matchDetailRepository.updateCurrentCommentary(matchId, savedCommentary.getContent(), savedCommentary.getId());
-        if (updatedCount == 0) {
-            log.warn("최신 중계 문구를 업데이트할 경기 정보를 찾을 수 없습니다. matchId:{}", matchId);
-            throw new BusinessException(ErrorCode.MATCH_NOT_FOUND, "최신 중계 문구를 업데이트할 경기 정보를 찾을 수 없습니다.");
-        }
+        // 3. MatchDetailDocument 가 있으면 현재 중계 멘트만 갱신하고, 없으면 현재 중계 멘트만 가진 문서를 생성한다.
+        matchDetailRepository.upsertCurrentCommentary(matchId, content, savedCommentary.getId());
 
         return savedCommentary.getId();
     }
@@ -67,5 +64,11 @@ public class MatchCommentaryService {
         return commentaryRepository.findVisibleCommentaries(matchId).stream()
                 .map(MatchCommentaryDocument::getContent)
                 .toList();
+    }
+
+    private void validateMatchExists(Long matchId) {
+        if (!matchRepository.existsById(matchId)) {
+            throw new BusinessException(ErrorCode.MATCH_NOT_FOUND);
+        }
     }
 }

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/repository/FakeMatchDetailRepository.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/repository/FakeMatchDetailRepository.java
@@ -37,17 +37,6 @@ public class FakeMatchDetailRepository implements MatchDetailRepository {
     }
 
     @Override
-    public long updateCurrentCommentary(Long matchId, String content, String commentaryId) {
-        List<MatchDetailDocument> matchDetailDocuments = database.values().stream()
-                .filter(matchDetail -> matchId.equals(matchDetail.getId()))
-                .toList();
-
-        matchDetailDocuments.forEach(matchDetailDocument -> matchDetailDocument.updateCurrentCommentary(content, commentaryId));
-
-        return matchDetailDocuments.size();
-    }
-
-    @Override
     public void upsertCurrentCommentary(Long matchId, String content, String commentaryId) {
         MatchDetailDocument saved = database.get(matchId);
 

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/repository/FakeMatchDetailRepository.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/repository/FakeMatchDetailRepository.java
@@ -21,6 +21,14 @@ public class FakeMatchDetailRepository implements MatchDetailRepository {
     }
 
     @Override
+    public List<MatchDetailDocument> findAllById(List<Long> matchIds) {
+        return matchIds.stream()
+                .map(database::get)
+                .filter(matchDetailDocument -> matchDetailDocument != null)
+                .toList();
+    }
+
+    @Override
     public MatchDetailDocument save(MatchDetailDocument matchDetail) {
         Long id = idGenerator.getAndIncrement();
         database.put(id, matchDetail);
@@ -37,6 +45,24 @@ public class FakeMatchDetailRepository implements MatchDetailRepository {
         matchDetailDocuments.forEach(matchDetailDocument -> matchDetailDocument.updateCurrentCommentary(content, commentaryId));
 
         return matchDetailDocuments.size();
+    }
+
+    @Override
+    public void upsertCurrentCommentary(Long matchId, String content, String commentaryId) {
+        MatchDetailDocument saved = database.get(matchId);
+
+        if (saved == null) {
+            MatchDetailDocument matchDetailDocument = MatchDetailDocument.builder()
+                    .id(matchId)
+                    .currentCommentary(content)
+                    .currentCommentaryId(commentaryId)
+                    .build();
+
+            database.put(matchId, matchDetailDocument);
+            return;
+        }
+
+        saved.updateCurrentCommentary(content, commentaryId);
     }
 
     @Override

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchAppQueryServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchAppQueryServiceTest.java
@@ -65,7 +65,6 @@ class MatchAppQueryServiceTest {
         assertThat(response.getCurrentCommentary()).isEqualTo("선제골 이후 홈팀이 흐름을 잡습니다.");
         assertThat(response.getHomeScore()).isEqualTo(1);
         assertThat(response.getAwayScore()).isEqualTo(0);
-        assertThat(response.getTimeInfo().getType()).isEqualTo("IN_PLAY");
         assertThat(response.getTimeInfo().getElapsedMinutes()).isEqualTo(27);
         assertThat(response.getTimeInfo().getPeriodCode()).isEqualTo("FIRST_HALF");
     }
@@ -82,7 +81,6 @@ class MatchAppQueryServiceTest {
 
         assertThat(result).hasSize(1);
         MatchAppResponse response = result.get(0);
-        assertThat(response.getTimeInfo().getType()).isEqualTo(MatchStatus.ENDED.name());
         assertThat(response.getTimeInfo().getResult()).isEqualTo(MatchResult.AWAY_WIN.name());
         assertThat(response.getTimeInfo().getWinnerTeamId()).isEqualTo(20L);
         assertThat(response.getTimeInfo().getWinnerTeamName()).isEqualTo("Away");

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchAppQueryServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchAppQueryServiceTest.java
@@ -1,0 +1,134 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import com.scorenow.scorenow_api.domain.common.enums.TeamDisplayOrder;
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.match.document.MatchDetailDocument;
+import com.scorenow.scorenow_api.domain.match.dto.response.MatchAppResponse;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.entity.MatchPeriod;
+import com.scorenow.scorenow_api.domain.match.entity.MatchResult;
+import com.scorenow.scorenow_api.domain.match.entity.MatchStatus;
+import com.scorenow.scorenow_api.domain.match.repository.MatchDetailRepository;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import com.scorenow.scorenow_api.domain.team.entity.Team;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class MatchAppQueryServiceTest {
+
+    @Mock
+    private MatchRepository matchRepository;
+
+    @Mock
+    private MatchDetailRepository matchDetailRepository;
+
+    @InjectMocks
+    private MatchAppQueryService matchAppQueryService;
+
+    @Test
+    void 진행중_경기는_MatchDetailDocument의_진행시간과_중계멘트를_조합한다() {
+        LocalDate date = LocalDate.of(2026, 6, 2);
+        Match match = createMatch(1L, MatchStatus.IN_PLAY, LocalDateTime.of(2026, 6, 2, 20, 0), 0, 0);
+        MatchDetailDocument detail = MatchDetailDocument.builder()
+                .id(match.getId())
+                .homeScore(1)
+                .awayScore(0)
+                .currentCommentary("선제골 이후 홈팀이 흐름을 잡습니다.")
+                .matchClock(MatchDetailDocument.MatchClock.builder()
+                        .elapsedMinutes(27)
+                        .elapsedSeconds(14)
+                        .period(MatchPeriod.FIRST_HALF)
+                        .running(true)
+                        .providerUpdatedAt(Instant.parse("2026-06-02T11:27:14Z"))
+                        .build())
+                .build();
+
+        givenAppMatches(date, match);
+        given(matchDetailRepository.findAllById(List.of(match.getId()))).willReturn(List.of(detail));
+
+        List<MatchAppResponse> result = matchAppQueryService.getMatches(date, 1L, 2L);
+
+        assertThat(result).hasSize(1);
+        MatchAppResponse response = result.get(0);
+        assertThat(response.getCurrentCommentary()).isEqualTo("선제골 이후 홈팀이 흐름을 잡습니다.");
+        assertThat(response.getHomeScore()).isEqualTo(1);
+        assertThat(response.getAwayScore()).isEqualTo(0);
+        assertThat(response.getTimeInfo().getType()).isEqualTo("IN_PLAY");
+        assertThat(response.getTimeInfo().getElapsedMinutes()).isEqualTo(27);
+        assertThat(response.getTimeInfo().getPeriodCode()).isEqualTo("FIRST_HALF");
+    }
+
+    @Test
+    void 종료된_경기는_점수를_기반으로_승패정보를_내려준다() {
+        LocalDate date = LocalDate.of(2026, 6, 2);
+        Match match = createMatch(2L, MatchStatus.ENDED, LocalDateTime.of(2026, 6, 2, 18, 0), 2, 3);
+
+        givenAppMatches(date, match);
+        given(matchDetailRepository.findAllById(List.of(match.getId()))).willReturn(List.of());
+
+        List<MatchAppResponse> result = matchAppQueryService.getMatches(date, 1L, 2L);
+
+        assertThat(result).hasSize(1);
+        MatchAppResponse response = result.get(0);
+        assertThat(response.getTimeInfo().getType()).isEqualTo(MatchStatus.ENDED.name());
+        assertThat(response.getTimeInfo().getResult()).isEqualTo(MatchResult.AWAY_WIN.name());
+        assertThat(response.getTimeInfo().getWinnerTeamId()).isEqualTo(20L);
+        assertThat(response.getTimeInfo().getWinnerTeamName()).isEqualTo("Away");
+    }
+
+    private void givenAppMatches(LocalDate date, Match match) {
+        given(matchRepository.findAppMatches(
+                date.atStartOfDay(),
+                date.plusDays(1).atStartOfDay(),
+                1L,
+                2L,
+                List.of(MatchStatus.IN_PLAY, MatchStatus.NOT_STARTED, MatchStatus.ENDED),
+                MatchStatus.IN_PLAY,
+                MatchStatus.NOT_STARTED,
+                MatchStatus.ENDED
+        )).willReturn(List.of(match));
+    }
+
+    private Match createMatch(Long id, MatchStatus status, LocalDateTime startAt, Integer homeScore, Integer awayScore) {
+        return Match.builder()
+                .id(id)
+                .sportId(1L)
+                .leagueId(2L)
+                .league(League.builder()
+                        .id(2L)
+                        .sName("EPL")
+                        .eName("Premier League")
+                        .build())
+                .homeId(10L)
+                .homeTeam(Team.builder()
+                        .id(10L)
+                        .sName("Home")
+                        .imageUrl("home.png")
+                        .build())
+                .awayId(20L)
+                .awayTeam(Team.builder()
+                        .id(20L)
+                        .sName("Away")
+                        .imageUrl("away.png")
+                        .build())
+                .startAt(startAt)
+                .statusCode(status)
+                .homeScore(homeScore)
+                .awayScore(awayScore)
+                .isActive(true)
+                .teamDisplayOrder(TeamDisplayOrder.HOME_AWAY)
+                .build();
+    }
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchCommentaryServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/MatchCommentaryServiceTest.java
@@ -4,33 +4,42 @@ import com.scorenow.scorenow_api.domain.match.document.MatchDetailDocument;
 import com.scorenow.scorenow_api.domain.match.repository.FakeFileStorage;
 import com.scorenow.scorenow_api.domain.match.repository.FakeMatchCommentaryRepository;
 import com.scorenow.scorenow_api.domain.match.repository.FakeMatchDetailRepository;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatRuntimeException;
+import static org.mockito.BDDMockito.given;
 
+@ExtendWith(MockitoExtension.class)
 class MatchCommentaryServiceTest {
     private MatchCommentaryService matchCommentaryService;
     private FakeMatchCommentaryRepository matchCommentaryRepository;
     private FakeMatchDetailRepository matchDetailRepository;
     private FakeFileStorage fileStorage;
 
+    @Mock
+    private MatchRepository matchRepository;
+
     @BeforeEach
     void setUp() {
         matchCommentaryRepository = new FakeMatchCommentaryRepository();
         matchDetailRepository = new FakeMatchDetailRepository();
         fileStorage = new FakeFileStorage();
-        matchCommentaryService = new MatchCommentaryService(matchCommentaryRepository, matchDetailRepository, fileStorage);
+        matchCommentaryService = new MatchCommentaryService(matchCommentaryRepository, matchDetailRepository, matchRepository, fileStorage);
     }
 
     @Test
     void 중계_정보에는_가장_최신의_중계_멘트만_조회된다() {
         MatchDetailDocument matchDetailDocument = createMatchDetailDocument();
         Long matchId = matchDetailDocument.getId();
+        given(matchRepository.existsById(matchId)).willReturn(true);
 
         boolean recordEnabled = true;
         matchCommentaryService.saveCommentary(matchId, "18", "손흥민 오늘 최고네요.", recordEnabled, null);
@@ -45,6 +54,7 @@ class MatchCommentaryServiceTest {
     void 중계_멘트_저장_ON_상태에서만_등록된_중계_멘트만_조회된다() {
         MatchDetailDocument matchDetailDocument = createMatchDetailDocument();
         Long matchId = matchDetailDocument.getId();
+        given(matchRepository.existsById(matchId)).willReturn(true);
 
         // 중계 멘트 저장 ON (3건)
         boolean recordEnabled = true;
@@ -65,9 +75,24 @@ class MatchCommentaryServiceTest {
     @Test
     void 존재하지_않는_경기에_중계멘트_저장시_예외가_발생한다() {
         Long invalidMatchId = 999L;
+        given(matchRepository.existsById(invalidMatchId)).willReturn(false);
 
         assertThatRuntimeException()
                 .isThrownBy(() -> matchCommentaryService.saveCommentary(invalidMatchId, "3", "메시 오늘 좋네요.", true, null));
+    }
+
+    @Test
+    void 중계_멘트를_저장하는데_MatchDetailDocument가_없으면_현재_중계_멘트를_가진_새로운_문서를_생성한다() {
+        Long matchId = 10L;
+        String elapsedMinutes = "3";
+        String content = "중계 멘트 입니다.";
+        given(matchRepository.existsById(matchId)).willReturn(true);
+
+        String commentaryId = matchCommentaryService.saveCommentary(matchId, elapsedMinutes, content, true, null);
+
+        MatchDetailDocument matchDetailDocument = matchDetailRepository.findById(matchId).get();
+        assertThat(matchDetailDocument.getCurrentCommentary()).isEqualTo(content);
+        assertThat(matchDetailDocument.getCurrentCommentaryId()).isEqualTo(commentaryId);
     }
 
     private MatchDetailDocument createMatchDetailDocument() {


### PR DESCRIPTION
## #️⃣ Issue Number
- #77 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
- 앱 제공 경기 리스트 조회 API
   - 기본 정렬 조건 : `진행중 > 경기 예정 > 경기 종료` 
- Swagger 추가

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
### 1. 앱 경기 목록 조회 Request

```http
GET /api/v1/app/matches
```

#### Query Parameters

| name | required | format | description |
| --- | --- | --- | --- |
| `date` | false | `yyyyMMdd` | 조회 날짜. 없으면 서버 기준 오늘 날짜로 조회 |
| `sportId` | false | number | 종목 ID 필터 |
| `leagueId` | false | number | 리그 ID 필터 |

예시:

```http
GET /api/v1/app/matches?date=20260605&sportId=1&leagueId=2
```
---

### 2. 앱 경기 목록 조회 Response

응답 타입은 `ApiResponse<List<MatchAppResponse>>`이다.

주요 필드:

| field | description |
| --- | --- |
| `id` | 경기 ID |
| `date` | 경기 날짜 |
| `leagueId`, `leagueName` | 리그 정보 |
| `homeTeam`, `awayTeam` | 홈/어웨이 팀 정보 |
| `homeScore`, `awayScore` | 점수 |
| `statusCode`, `statusName` | 경기 상태 |
| `currentCommentary` | 현재 앱에 보여줄 중계 멘트 |
| `timeInfo` | 경기 시간 정보 |
| `teamDisplayOrder` | 앱에서 팀을 표시할 순서 |

`timeInfo`는 경기 상태에 따라 채워지는 필드가 다르다.

- `NOT_STARTED (경기전)`: `startAt`
- `IN_PLAY (경기중)`: `elapsedMinutes`, `elapsedSeconds`, `periodCode`, `periodName`, `running`
- `ENDED (경기종료)`: `result`, `winnerTeamId`, `winnerTeamName`
---
### 3. MatchPeriod 추가
- 기존에는 Bets 에서 내려주는 `timer.md` 값이 `0:전반, 1:후반` 만 확인되어서 해당 부분만 관리
- `연장 전반(2), 연장 후반(3), 승부차기(4)` 에 대한 값을 확인하여, 이번 PR 을 통해 추가

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
