### PR TITLE
fix : Cloud Run JVM timezone 및 인플레이 후보 조회 시간 기준 보정

### DIFF
--- a/src/main/java/com/scorenow/scorenow_api/domain/match/constant/MatchConstants.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/constant/MatchConstants.java
@@ -1,10 +1,13 @@
 package com.scorenow.scorenow_api.domain.match.constant;
 
+import java.time.ZoneId;
+
 public final class MatchConstants {
     private MatchConstants() {
     }
 
     public static final String SEOUL_TIME_ZONE = "Asia/Seoul";
+    public static final ZoneId SEOUL_TIME_ZONE_ID = ZoneId.of(SEOUL_TIME_ZONE);
 
     public static final String INPLAY_CANDIDATES_KEY = "inplay_candidates";
     public static final long INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS = 1L;

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchSyncScheduler.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/scheduler/MatchSyncScheduler.java
@@ -1,6 +1,7 @@
 package com.scorenow.scorenow_api.domain.match.scheduler;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 import com.scorenow.scorenow_api.domain.match.service.InplayMatchCandidateLoadService;
 import com.scorenow.scorenow_api.domain.match.service.InplayMatchSyncService;
@@ -16,6 +17,8 @@ import com.scorenow.scorenow_api.domain.match.service.MatchSyncService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import static com.scorenow.scorenow_api.domain.match.constant.MatchConstants.SEOUL_TIME_ZONE_ID;
 
 @Profile("!test")
 @Slf4j
@@ -77,7 +80,7 @@ public class MatchSyncScheduler {
         log.info("📅 INPLAY 예정 경기 캐싱 시작");
 
         try {
-            inplayMatchCandidateLoadService.loadInplayCandidatesToCache(LocalDateTime.now());
+            inplayMatchCandidateLoadService.loadInplayCandidatesToCache(ZonedDateTime.now(SEOUL_TIME_ZONE_ID));
         } catch (Exception e) {
             log.error("시작 예정 경기 캐싱 작업 중 예외 발생 ❌", e);
         }
@@ -92,7 +95,7 @@ public class MatchSyncScheduler {
         log.info("📅 INPLAY 경기 동기화 시작");
 
         try {
-            inplayMatchSyncService.syncInplayMatches(LocalDateTime.now());
+            inplayMatchSyncService.syncInplayMatches(ZonedDateTime.now(SEOUL_TIME_ZONE_ID));
         } catch (Exception e) {
             log.error("INPLAY 경기 동기화 처리 중 예외 발생 ❌", e);
         }

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
@@ -7,8 +7,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -22,18 +20,20 @@ import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.NOT_STAR
 public class InplayMatchCandidateLoadService {
 
     private static final DateTimeFormatter LOG_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
-    private static final ZoneId SEOUL_TIME_ZONE_ID = ZoneId.of(SEOUL_TIME_ZONE);
 
     private final MatchRepository matchRepository;
     private final InplayMatchRedisRepository inplayMatchRedisRepository;
 
-    public void loadInplayCandidatesToCache(LocalDateTime standardTime) {
-        ZonedDateTime standardTimeWithZone = standardTime.atZone(SEOUL_TIME_ZONE_ID);
+    public void loadInplayCandidatesToCache(ZonedDateTime standardTime) {
+        ZonedDateTime standardTimeInSeoul = standardTime.withZoneSameInstant(SEOUL_TIME_ZONE_ID);
 
-        ZonedDateTime start = standardTimeWithZone.minusMinutes(INPLAY_CANDIDATE_SCAN_LOOKBACK_MINUTES);
-        ZonedDateTime end = standardTimeWithZone.plusHours(INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS);
+        ZonedDateTime start = standardTimeInSeoul.minusMinutes(INPLAY_CANDIDATE_SCAN_LOOKBACK_MINUTES);
+        ZonedDateTime end = standardTimeInSeoul.plusHours(INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS);
 
-        List<MatchCandidate> candidates = matchRepository.findMatchesStartingWithin(NOT_STARTED, start.toLocalDateTime(), end.toLocalDateTime());
+        List<MatchCandidate> candidates = matchRepository.findMatchesStartingWithin(
+                NOT_STARTED,
+                start.toLocalDateTime(),
+                end.toLocalDateTime());
 
         log.info(
                 "시작 예정 경기 조회 범위: {} ~ {}, {}시간 이내 시작 예정 경기 건수: {}",

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static com.scorenow.scorenow_api.domain.match.constant.MatchConstants.*;
@@ -20,6 +21,7 @@ import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.NOT_STAR
 @RequiredArgsConstructor
 public class InplayMatchCandidateLoadService {
 
+    private static final DateTimeFormatter LOG_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
     private static final ZoneId SEOUL_TIME_ZONE_ID = ZoneId.of(SEOUL_TIME_ZONE);
 
     private final MatchRepository matchRepository;
@@ -33,7 +35,13 @@ public class InplayMatchCandidateLoadService {
 
         List<MatchCandidate> candidates = matchRepository.findMatchesStartingWithin(NOT_STARTED, start.toLocalDateTime(), end.toLocalDateTime());
 
-        log.info("{}시간 이내 시작 예정 경기 건수 : {}", INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS, candidates.size());
+        log.info(
+                "시작 예정 경기 조회 범위: {} ~ {}, {}시간 이내 시작 예정 경기 건수: {}",
+                start.format(LOG_TIME_FORMATTER),
+                end.format(LOG_TIME_FORMATTER),
+                INPLAY_CANDIDATES_SCAN_INTERVAL_HOURS,
+                candidates.size()
+        );
 
         for (MatchCandidate candidate : candidates) {
             ZonedDateTime startAt = candidate.getStartAt().atZone(SEOUL_TIME_ZONE_ID);

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncService.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +27,8 @@ public class InplayMatchSyncService {
     private final InplayMatchStatusUpdater inplayMatchStatusUpdater;
     private final InplayMatchRedisRepository inplayMatchRedisRepository;
 
-    public void syncInplayMatches(LocalDateTime standardTime) {
-        ZonedDateTime now = standardTime.atZone(ZoneId.of(SEOUL_TIME_ZONE));
+    public void syncInplayMatches(ZonedDateTime standardTime) {
+        ZonedDateTime now = standardTime.withZoneSameInstant(SEOUL_TIME_ZONE_ID);
 
         // 1. 동기화 대상 조회 (현재 시간 기준 INPLAY 일 것으로 예상되는 경기들)
         List<MatchCandidate> candidates = inplayMatchRedisRepository.findCandidatesToSync(now);

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchCandidateLoadServiceTest.java
@@ -10,13 +10,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import static com.scorenow.scorenow_api.domain.match.constant.MatchConstants.SEOUL_TIME_ZONE_ID;
 import static com.scorenow.scorenow_api.domain.match.entity.MatchStatus.NOT_STARTED;
 import static com.scorenow.scorenow_api.domain.common.enums.DataOrigin.BETS;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
@@ -35,7 +36,7 @@ class InplayMatchCandidateLoadServiceTest {
 
     @Test
     void 시작_예정인_경기를_DB에서_조회하여_Redis에_캐싱한다() {
-        ZonedDateTime now = ZonedDateTime.of(2026, 1, 1, 13, 0, 0, 0, ZoneId.of("Asia/Seoul"));
+        ZonedDateTime now = ZonedDateTime.of(2026, 1, 1, 13, 0, 0, 0, SEOUL_TIME_ZONE_ID);
 
         // 1시간 이내 시작 예정 경기 2건 세팅
         MatchCandidate candidate1 = new MatchCandidate(1L, 1L, BETS, "100", "1", LocalDateTime.of(2026, 1, 1, 13, 30));
@@ -43,13 +44,13 @@ class InplayMatchCandidateLoadServiceTest {
         List<MatchCandidate> candidates = List.of(candidate1, candidate2);
 
         // 1시간 이내 시작 예정인 경기 목록 조회 시 반환 값 세팅
-        given(matchRepository.findMatchesStartingWithin(NOT_STARTED, now.toLocalDateTime(), now.plusHours(1L).toLocalDateTime()))
+        given(matchRepository.findMatchesStartingWithin(eq(NOT_STARTED), any(), any()))
                 .willReturn(candidates);
 
-        service.loadInplayCandidatesToCache(now.toLocalDateTime());
+        service.loadInplayCandidatesToCache(now);
 
         // MatchRepository.findMatchesStartingWithin 1회 호출되었음을 검증
-        then(matchRepository).should(times(1)).findMatchesStartingWithin(any(), any(), any());
+        then(matchRepository).should(times(1)).findMatchesStartingWithin(eq(NOT_STARTED), any(), any());
 
         // InplayMatchRedisRepository.addCandidate {candidates.size} 만큼 호출되었음을 검증
         then(inplayMatchRedisRepository).should(times(candidates.size())).addCandidate(any(), any());

--- a/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/match/service/InplayMatchSyncServiceTest.java
@@ -10,13 +10,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static com.scorenow.scorenow_api.domain.common.enums.DataOrigin.BETS;
+import static com.scorenow.scorenow_api.domain.match.constant.MatchConstants.SEOUL_TIME_ZONE_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -39,7 +39,7 @@ class InplayMatchSyncServiceTest {
 
     @Test
     void API_응답을_대조하여_진행_중인_경기와_유예기간_초과_경기를_정상적으로_분류하고_반영한다() {
-        ZonedDateTime now = ZonedDateTime.of(2026, 1, 1, 13, 30, 0, 0, ZoneId.of("Asia/Seoul"));
+        ZonedDateTime now = ZonedDateTime.of(2026, 1, 1, 13, 30, 0, 0, SEOUL_TIME_ZONE_ID);
 
         // 동기화 대상 조회 결과 세팅 현재 시작 예정 경기 세팅 (축구 2건 + 야구 1건 + 농구 1건) / 농구의 경우 유예기간 초과 경기
         MatchCandidate soccerCandidate1 = new MatchCandidate(1L, 1L, BETS, "100", "SOCCER", now.toLocalDateTime());
@@ -58,7 +58,7 @@ class InplayMatchSyncServiceTest {
         given(betsApiClient.getInplayEvents("BASEBALL", null)).willReturn(inplayBaseball);
         given(betsApiClient.getInplayEvents("BASKETBALL", null)).willReturn(inplayBasketball);
 
-        service.syncInplayMatches(now.toLocalDateTime());
+        service.syncInplayMatches(now);
 
         // API 총 3회 호출 (축구 1회, 야구 1회, 농구 1회)
         then(betsApiClient).should(times(1)).getInplayEvents("SOCCER", null);


### PR DESCRIPTION
## #️⃣ Issue Number
- #96 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
#### 인플레이 후보 캐싱/동기화 로직의 기준 시간을 `LocalDateTime`에서 `ZonedDateTime`으로 변경

  - 기존에는 스케줄러에서 `LocalDateTime.now()`를 사용해 기준 시간을 전달
  
  - `LocalDateTime.now()`는 JVM default timezone을 기준으로 값을 생성하지만, 값 자체에는 timezone 정보가 포함되지 않음
  
  - 따라서 로컬과 개발 서버의 JVM default timezone이 다르면 동일한 코드라도 서로 다른 기준 시간이 만들어질 수 있음

#### 현재 `match.startAt`은 DB에 KST 기준 로컬 경기 시간으로 저장

  - 예: `2026-06-16 20:00:00`
  
  - DB의 `DATETIME`과 Java의 `LocalDateTime`은 timezone 정보를 가지지 않으므로, 이 값은 “KST 기준 20시”라는 서비스 정책에 따라 해석된다

#### 인플레이 후보 캐싱/동기화 로직은 경기 시작 시간(KST) 을 기준으로 동작하므로, 기준 시간을 명확히 KST로 맞추도록 수정
  - 스케줄러에서는 `ZonedDateTime.now(SEOUL_TIME_ZONE_ID)`를 서비스로 전달
  - 서비스 내부에서는 `withZoneSameInstant(SEOUL_TIME_ZONE_ID)`로 서울 시간 기준으로 정규화
  
     > 다른 타임존 시간대의 값이 넘어오더라도, 항상 해당 부분은 서울 기준으로 동작하는 것을 보장하기 위함



## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
