### PR TITLE
Feat: 경기 채팅 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     //jwt 관련 설정 추가
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/controller/ChatHistoryController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/controller/ChatHistoryController.java
@@ -1,0 +1,44 @@
+package com.scorenow.scorenow_api.domain.chat.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageSliceResponse;
+import com.scorenow.scorenow_api.domain.chat.service.ChatHistoryService;
+import com.scorenow.scorenow_api.global.dto.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat")
+@Tag(name = "Chat - history", description = "채팅 내역 API")
+public class ChatHistoryController {
+
+	private static final String DEFAULT_SIZE = "30";
+
+	private final ChatHistoryService chatHistoryService;
+
+	@Operation(summary = "채팅 내역 조회", description = """
+		특정 경기의 채팅 내역을 커서 기반 무한스크롤 방식으로 조회합니다.
+
+		- cursor가 없으면 최신 메시지부터 조회합니다.
+		- cursor가 있으면 해당 메시지 ID보다 오래된 메시지를 조회합니다.
+		- 응답의 nextCursor를 다음 요청의 cursor로 사용하면 됩니다.
+		""")
+	@GetMapping("/{matchId}/history")
+	public ApiResponse<ChatMessageSliceResponse> getHistory(
+		@Parameter(description = "경기 ID", example = "1") @PathVariable Long matchId,
+
+		@Parameter(description = "커서 메시지 ID. 해당 ID보다 오래된 메시지를 조회합니다.", example = "150") @RequestParam(required = false) Long cursor,
+
+		@Parameter(description = "조회할 메시지 개수", example = "30") @RequestParam(defaultValue = DEFAULT_SIZE) int size) {
+		return ApiResponse.success(chatHistoryService.getMessages(matchId, cursor, size));
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/controller/ChatMessageController.java
@@ -1,0 +1,33 @@
+package com.scorenow.scorenow_api.domain.chat.controller;
+
+import java.security.Principal;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageRequest;
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageResponse;
+import com.scorenow.scorenow_api.domain.chat.service.ChatMessageService;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+	private final ChatMessageService chatMessageService;
+	private final SimpMessagingTemplate messagingTemplate;
+
+	@MessageMapping("/matches/{matchId}/chat/messages")
+	public void sendMessage(@DestinationVariable Long matchId, @Payload ChatMessageRequest request,
+		Principal principal) {
+		Long userId = Long.parseLong(principal.getName());
+
+		ChatMessageResponse response = chatMessageService.createMessage(matchId, userId, request);
+
+		messagingTemplate.convertAndSend("/sub/matches/" + matchId + "/chat/messages", response);
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/controller/ChatMessageController.java
@@ -3,6 +3,7 @@ package com.scorenow.scorenow_api.domain.chat.controller;
 import java.security.Principal;
 
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -11,6 +12,10 @@ import org.springframework.stereotype.Controller;
 import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageRequest;
 import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageResponse;
 import com.scorenow.scorenow_api.domain.chat.service.ChatMessageService;
+import com.scorenow.scorenow_api.global.dto.ApiResponse;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import com.scorenow.scorenow_api.global.websocket.principal.StompPrincipal;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,10 +29,41 @@ public class ChatMessageController {
 	@MessageMapping("/matches/{matchId}/chat/messages")
 	public void sendMessage(@DestinationVariable Long matchId, @Payload ChatMessageRequest request,
 		Principal principal) {
-		Long userId = Long.parseLong(principal.getName());
+		StompPrincipal stompPrincipal = getStompPrincipal(principal);
+		validateRequest(request);
 
-		ChatMessageResponse response = chatMessageService.createMessage(matchId, userId, request);
+		ChatMessageResponse response = chatMessageService.createMessage(matchId, stompPrincipal.getUserId(), request);
 
 		messagingTemplate.convertAndSend("/sub/matches/" + matchId + "/chat/messages", response);
+	}
+
+	@MessageExceptionHandler(BusinessException.class)
+	public void handleBusinessException(BusinessException exception, Principal principal) {
+		if (principal == null) {
+			return;
+		}
+
+		ErrorCode errorCode = exception.getErrorCode();
+		ApiResponse<Void> response = ApiResponse.error(
+			errorCode.getCode(),
+			exception.getMessage(),
+			exception.getDetails()
+		);
+
+		messagingTemplate.convertAndSendToUser(principal.getName(), "/queue/errors", response);
+	}
+
+	private StompPrincipal getStompPrincipal(Principal principal) {
+		if (!(principal instanceof StompPrincipal stompPrincipal)) {
+			throw new BusinessException(ErrorCode.CHAT_SEND_AUTH_REQUIRED);
+		}
+
+		return stompPrincipal;
+	}
+
+	private void validateRequest(ChatMessageRequest request) {
+		if (request == null || request.getMessage() == null) {
+			throw new BusinessException(ErrorCode.CHAT_MESSAGE_INVALID);
+		}
 	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/dto/ChatMessageRequest.java
@@ -1,0 +1,10 @@
+package com.scorenow.scorenow_api.domain.chat.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatMessageRequest {
+	private String message;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,27 @@
+package com.scorenow.scorenow_api.domain.chat.dto;
+
+import java.time.LocalDateTime;
+
+import com.scorenow.scorenow_api.domain.chat.entity.ChatMessage;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatMessageResponse {
+
+	private Long matchId;
+	private String senderNickname;
+	private String message;
+	private LocalDateTime createdAt;
+
+	public static ChatMessageResponse from(ChatMessage chatMessage) {
+		return ChatMessageResponse.builder()
+			.matchId(chatMessage.getMatchId())
+			.senderNickname(chatMessage.getSenderNickname())
+			.message(chatMessage.getMessage())
+			.createdAt(chatMessage.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/dto/ChatMessageResponse.java
@@ -16,9 +16,9 @@ public class ChatMessageResponse {
 	private String message;
 	private LocalDateTime createdAt;
 
-	public static ChatMessageResponse from(ChatMessage chatMessage) {
+	public static ChatMessageResponse of(ChatMessage chatMessage, Long matchId) {
 		return ChatMessageResponse.builder()
-			.matchId(chatMessage.getMatchId())
+			.matchId(matchId)
 			.senderNickname(chatMessage.getSenderNickname())
 			.message(chatMessage.getMessage())
 			.createdAt(chatMessage.getCreatedAt())

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/dto/ChatMessageSliceResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/dto/ChatMessageSliceResponse.java
@@ -1,0 +1,19 @@
+package com.scorenow.scorenow_api.domain.chat.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatMessageSliceResponse {
+
+	private List<ChatMessageResponse> messages;
+	private Long nextCursor;
+	private boolean hasNext;
+
+	public static ChatMessageSliceResponse of(List<ChatMessageResponse> messages, Long nextCursor, boolean hasNext) {
+		return ChatMessageSliceResponse.builder().messages(messages).nextCursor(nextCursor).hasNext(hasNext).build();
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,86 @@
+package com.scorenow.scorenow_api.domain.chat.entity;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.user.entity.User;
+import com.scorenow.scorenow_api.global.entity.BaseEntity;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "chat_messages", indexes = {@Index(name = "idx_chat_messages_match_id_id", columnList = "match_id, id")})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseEntity {
+
+	private static final int MAX_MESSAGE_LENGTH = 1000;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "match_id", nullable = false, foreignKey = @ForeignKey(name = "fk_chat_messages_match"))
+	@OnDelete(action = OnDeleteAction.CASCADE)
+	private Match match;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_chat_messages_user"))
+	@OnDelete(action = OnDeleteAction.CASCADE)
+	private User user;
+
+	@Column(name = "sender_nickname", nullable = false)
+	private String senderNickname;
+
+	@Column(nullable = false, length = MAX_MESSAGE_LENGTH)
+	private String message;
+
+	public Long getMatchId() {
+		return match.getId();
+	}
+
+	public Long getUserId() {
+		return user.getId();
+	}
+
+	public static ChatMessage create(Match match, User sender, String message) {
+		validateMatch(match);
+		validateSender(sender);
+		validateMessage(message);
+
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.match = match;
+		chatMessage.user = sender;
+		chatMessage.senderNickname = sender.getNickname();
+		chatMessage.message = message.trim();
+
+		return chatMessage;
+	}
+
+	private static void validateMatch(Match match) {
+		if (match == null) {
+			throw new BusinessException(ErrorCode.MATCH_NOT_FOUND);
+		}
+	}
+
+	private static void validateSender(User sender) {
+		if (sender == null) {
+			throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+		}
+	}
+
+	private static void validateMessage(String message) {
+		if (message == null || message.isBlank()) {
+			throw new BusinessException(ErrorCode.CHAT_MESSAGE_INVALID);
+		}
+
+		if (message.trim().length() > MAX_MESSAGE_LENGTH) {
+			throw new BusinessException(ErrorCode.CHAT_MESSAGE_LENGTH_EXCEEDED);
+		}
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,15 @@
+package com.scorenow.scorenow_api.domain.chat.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.scorenow.scorenow_api.domain.chat.entity.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+	List<ChatMessage> findByMatch_IdOrderByIdDesc(Long matchId, Pageable pageable);
+
+	List<ChatMessage> findByMatch_IdAndIdLessThanOrderByIdDesc(Long matchId, Long cursor, Pageable pageable);
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/service/ChatHistoryService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/service/ChatHistoryService.java
@@ -37,7 +37,7 @@ public class ChatHistoryService {
 		List<ChatMessage> slicedMessages = sliceMessages(messages, size);
 		Long nextCursor = getNextCursor(slicedMessages);
 
-		return ChatMessageSliceResponse.of(toResponses(slicedMessages), nextCursor, hasNext);
+		return ChatMessageSliceResponse.of(toResponses(slicedMessages, matchId), nextCursor, hasNext);
 	}
 
 	private void validateSize(int size) {
@@ -76,7 +76,9 @@ public class ChatHistoryService {
 		return messages.get(messages.size() - 1).getId();
 	}
 
-	private List<ChatMessageResponse> toResponses(List<ChatMessage> messages) {
-		return messages.stream().map(ChatMessageResponse::from).toList();
+	private List<ChatMessageResponse> toResponses(List<ChatMessage> messages, Long matchId) {
+		return messages.stream()
+			.map(message -> ChatMessageResponse.of(message, matchId))
+			.toList();
 	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/service/ChatHistoryService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/service/ChatHistoryService.java
@@ -1,0 +1,82 @@
+package com.scorenow.scorenow_api.domain.chat.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageResponse;
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageSliceResponse;
+import com.scorenow.scorenow_api.domain.chat.entity.ChatMessage;
+import com.scorenow.scorenow_api.domain.chat.repository.ChatMessageRepository;
+import com.scorenow.scorenow_api.domain.match.service.MatchReferenceService;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatHistoryService {
+
+	private static final int MAX_SIZE = 100;
+
+	private final ChatMessageRepository chatMessageRepository;
+	private final MatchReferenceService matchReferenceService;
+
+	@Transactional(readOnly = true)
+	public ChatMessageSliceResponse getMessages(Long matchId, Long cursor, int size) {
+		validateSize(size);
+		matchReferenceService.requireMatch(matchId);
+
+		List<ChatMessage> messages = findMessages(matchId, cursor, size);
+		boolean hasNext = hasNext(messages, size);
+
+		List<ChatMessage> slicedMessages = sliceMessages(messages, size);
+		Long nextCursor = getNextCursor(slicedMessages);
+
+		return ChatMessageSliceResponse.of(toResponses(slicedMessages), nextCursor, hasNext);
+	}
+
+	private void validateSize(int size) {
+		if (size <= 0 || size > MAX_SIZE) {
+			throw new BusinessException(ErrorCode.INVALID_PARAMETER);
+		}
+	}
+
+	private List<ChatMessage> findMessages(Long matchId, Long cursor, int size) {
+		Pageable pageable = PageRequest.of(0, size + 1);
+
+		if (cursor == null) {
+			return chatMessageRepository.findByMatch_IdOrderByIdDesc(matchId, pageable);
+		}
+
+		return chatMessageRepository.findByMatch_IdAndIdLessThanOrderByIdDesc(matchId, cursor, pageable);
+	}
+
+	private boolean hasNext(List<ChatMessage> messages, int size) {
+		return messages.size() > size;
+	}
+
+	private List<ChatMessage> sliceMessages(List<ChatMessage> messages, int size) {
+		if (messages.size() <= size) {
+			return messages;
+		}
+
+		return messages.subList(0, size);
+	}
+
+	private Long getNextCursor(List<ChatMessage> messages) {
+		if (messages.isEmpty()) {
+			return null;
+		}
+
+		return messages.get(messages.size() - 1).getId();
+	}
+
+	private List<ChatMessageResponse> toResponses(List<ChatMessage> messages) {
+		return messages.stream().map(ChatMessageResponse::from).toList();
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/service/ChatMessageService.java
@@ -33,6 +33,6 @@ public class ChatMessageService {
 
 		ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
 
-		return ChatMessageResponse.from(savedMessage);
+		return ChatMessageResponse.of(savedMessage, matchId);
 	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,38 @@
+package com.scorenow.scorenow_api.domain.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageRequest;
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageResponse;
+import com.scorenow.scorenow_api.domain.chat.entity.ChatMessage;
+import com.scorenow.scorenow_api.domain.chat.repository.ChatMessageRepository;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.service.MatchReferenceService;
+import com.scorenow.scorenow_api.domain.user.entity.User;
+import com.scorenow.scorenow_api.domain.user.service.UserReferenceService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+	private final MatchReferenceService matchReferenceService;
+	private final ChatMessageRepository chatMessageRepository;
+	private final UserReferenceService userReferenceService;
+
+	@Transactional
+	public ChatMessageResponse createMessage(Long matchId, Long userId, ChatMessageRequest request) {
+
+		Match match = matchReferenceService.requireMatch(matchId);
+
+		User sendUser = userReferenceService.requireActiveUser(userId);
+
+		ChatMessage chatMessage = ChatMessage.create(match, sendUser, request.getMessage());
+
+		ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+
+		return ChatMessageResponse.from(savedMessage);
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchReferenceService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/service/MatchReferenceService.java
@@ -1,0 +1,24 @@
+package com.scorenow.scorenow_api.domain.match.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.repository.jpa.MatchRepository;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MatchReferenceService {
+
+	private final MatchRepository matchRepository;
+
+	public Match requireMatch(Long matchId) {
+		return matchRepository.findById(matchId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.MATCH_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/user/service/UserReferenceService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/user/service/UserReferenceService.java
@@ -1,0 +1,31 @@
+package com.scorenow.scorenow_api.domain.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.scorenow.scorenow_api.domain.user.entity.User;
+import com.scorenow.scorenow_api.domain.user.enums.UserStatus;
+import com.scorenow.scorenow_api.domain.user.repository.UserRepository;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserReferenceService {
+
+	private final UserRepository userRepository;
+
+	public User requireActiveUser(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		if (user.getStatus() != UserStatus.ACTIVE) {
+			throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+		}
+
+		return user;
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/global/config/SecurityConfig.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/config/SecurityConfig.java
@@ -2,7 +2,9 @@ package com.scorenow.scorenow_api.global.config;
 
 import com.scorenow.scorenow_api.domain.user.jwt.JwtAuthenticationFilter;
 import com.scorenow.scorenow_api.domain.user.jwt.JwtProvider;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -20,56 +22,58 @@ import java.util.List;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final JwtProvider jwtProvider;
+	private final JwtProvider jwtProvider;
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // ← 추가
-                .csrf(csrf -> csrf.disable())
-                //jwt사용 세션 stateless
-                .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        // Swagger 관련 리소스 전체 접근 허용
-                        .requestMatchers(
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/api/test/betsapi/**",
-                                "/api/v1/**"
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.cors(cors -> cors.configurationSource(corsConfigurationSource())) // ← 추가
+			.csrf(csrf -> csrf.disable())
+			//jwt사용 세션 stateless
+			.sessionManagement(session ->
+				session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				// Swagger 관련 리소스 전체 접근 허용
+				.requestMatchers(
+					"/v3/api-docs/**",
+					"/swagger-ui/**",
+					"/swagger-ui.html",
+					"/api/test/betsapi/**",
+					"/api/v1/**"
 
-                        ).permitAll()
-                        // Admin API 접근 허용 (개발 환경)
-                        .requestMatchers("/api/admin/**").permitAll()
-                        // 토큰없이 접근 가능한 인증 API
-                        .requestMatchers(
-                                "/api/v1/auth/social-login",
-                                "/api/v1/auth/refresh"
-                        ).permitAll()
-                        .anyRequest().authenticated()
-                )
-                .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtProvider),
-                        UsernamePasswordAuthenticationFilter.class);
-        return http.build();
-    }
+				).permitAll()
+				// Admin API 접근 허용 (개발 환경)
+				.requestMatchers("/api/admin/**").permitAll()
+				// 토큰없이 접근 가능한 인증 API
+				.requestMatchers(
+					"/api/v1/auth/social-login",
+					"/api/v1/auth/refresh",
+					"/ws/**",
+					"/ws"
+				).permitAll()
+				.anyRequest().authenticated()
+			)
+			.addFilterBefore(
+				new JwtAuthenticationFilter(jwtProvider),
+				UsernamePasswordAuthenticationFilter.class);
+		return http.build();
+	}
 
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration config = new CorsConfiguration();
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOrigins(List.of(
-                "http://localhost:5173"   // 로컬 프론트
-//                ex) "https://scorenow.com"     // 운영 도메인으로 변경
-        ));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-        config.setAllowedHeaders(List.of("*"));
-        config.setAllowCredentials(true); // 쿠키/인증 헤더 허용
-        config.setMaxAge(3600L); // preflight 캐시 1시간
+		config.setAllowedOrigins(List.of(
+			"http://localhost:5173"   // 로컬 프론트
+			//                ex) "https://scorenow.com"     // 운영 도메인으로 변경
+		));
+		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+		config.setAllowedHeaders(List.of("*"));
+		config.setAllowCredentials(true); // 쿠키/인증 헤더 허용
+		config.setMaxAge(3600L); // preflight 캐시 1시간
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", config);
-        return source;
-    }
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", config);
+		return source;
+	}
 }

--- a/src/main/java/com/scorenow/scorenow_api/global/config/WebSocketConfig.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/config/WebSocketConfig.java
@@ -19,7 +19,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		this.stompAuthChannelInterceptor = stompAuthChannelInterceptor;
 	}
 
-
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws")
@@ -28,7 +27,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
-		registry.enableSimpleBroker("/sub");
+		registry.enableSimpleBroker("/sub", "/queue");
 		registry.setApplicationDestinationPrefixes("/pub");
 	}
 

--- a/src/main/java/com/scorenow/scorenow_api/global/config/WebSocketConfig.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/config/WebSocketConfig.java
@@ -1,0 +1,39 @@
+package com.scorenow.scorenow_api.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import com.scorenow.scorenow_api.global.websocket.interceptor.StompAuthChannelInterceptor;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+
+	public WebSocketConfig(StompAuthChannelInterceptor stompAuthChannelInterceptor) {
+		this.stompAuthChannelInterceptor = stompAuthChannelInterceptor;
+	}
+
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws")
+			.setAllowedOriginPatterns("*");
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.enableSimpleBroker("/sub");
+		registry.setApplicationDestinationPrefixes("/pub");
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(stompAuthChannelInterceptor);
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
@@ -49,9 +49,14 @@ public enum ErrorCode {
 	// Token
 	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A001", "만료된 토큰입니다."),
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다."),
-    TOKEN_TYPE_MISMATCH(HttpStatus.UNAUTHORIZED, "A003", "RefreshToken이 아닙니다.");
+    TOKEN_TYPE_MISMATCH(HttpStatus.UNAUTHORIZED, "A003", "RefreshToken이 아닙니다."),
+	ACCESS_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "A004", "AccessToken이 필요합니다."),
 
-
+	// Chat
+	CHAT_SEND_AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "CH001", "채팅 전송에는 로그인이 필요합니다."),
+	CHAT_MESSAGE_INVALID(HttpStatus.BAD_REQUEST, "CH002", "채팅 메시지가 올바르지 않습니다."),
+	CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CH003", "채팅방을 찾을 수 없습니다."),
+	CHAT_MESSAGE_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "CH004", "채팅 메시지는 1000자를 초과할 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/exception/ErrorCode.java
@@ -41,15 +41,14 @@ public enum ErrorCode {
 
 	// User
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
-    NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "U002", "이미 사용중인 닉네임입니다."),
-	REJOIN_RESTRICTED(HttpStatus.CONFLICT,"U003","재가입이 제한된 계정입니다."),
-	NICKNAME_RESTRICTED(HttpStatus.CONFLICT,"U004","60일 이내 닉네임 재설정 불가합니다."),
-
+	NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "U002", "이미 사용중인 닉네임입니다."),
+	REJOIN_RESTRICTED(HttpStatus.CONFLICT, "U003", "재가입이 제한된 계정입니다."),
+	NICKNAME_RESTRICTED(HttpStatus.CONFLICT, "U004", "60일 이내 닉네임 재설정 불가합니다."),
 
 	// Token
 	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A001", "만료된 토큰입니다."),
-    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다."),
-    TOKEN_TYPE_MISMATCH(HttpStatus.UNAUTHORIZED, "A003", "RefreshToken이 아닙니다."),
+	TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다."),
+	TOKEN_TYPE_MISMATCH(HttpStatus.UNAUTHORIZED, "A003", "RefreshToken이 아닙니다."),
 	ACCESS_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "A004", "AccessToken이 필요합니다."),
 
 	// Chat

--- a/src/main/java/com/scorenow/scorenow_api/global/websocket/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/websocket/interceptor/StompAuthChannelInterceptor.java
@@ -17,9 +17,9 @@ import com.scorenow.scorenow_api.global.exception.ErrorCode;
 public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
 	private static final Pattern CHAT_SEND_DESTINATION = Pattern.compile("^/pub/matches/\\d+/chat/messages$");
-	private final StompJwtAuthenticator stompJwtAuthenticator;
-
 	private static final Pattern CHAT_SUBSCRIBE_DESTINATION = Pattern.compile("^/sub/matches/\\d+/chat/messages$");
+
+	private final StompJwtAuthenticator stompJwtAuthenticator;
 
 	public StompAuthChannelInterceptor(StompJwtAuthenticator stompJwtAuthenticator) {
 		this.stompJwtAuthenticator = stompJwtAuthenticator;
@@ -33,10 +33,10 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
 		if (StompCommand.CONNECT.equals(command)) {
 			stompJwtAuthenticator.authenticateIfTokenExists(accessor);
 		} else if (StompCommand.SEND.equals(command)) {
-			validateDestination(accessor.getDestination(),CHAT_SEND_DESTINATION);
+			validateDestination(accessor.getDestination(), CHAT_SEND_DESTINATION);
 			validateAuthenticatedUser(accessor.getUser());
 		} else if (StompCommand.SUBSCRIBE.equals(command)) {
-			validateDestination(accessor.getDestination(),CHAT_SUBSCRIBE_DESTINATION);
+			validateDestination(accessor.getDestination(), CHAT_SUBSCRIBE_DESTINATION);
 		}
 
 		return message;

--- a/src/main/java/com/scorenow/scorenow_api/global/websocket/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/websocket/interceptor/StompAuthChannelInterceptor.java
@@ -1,0 +1,56 @@
+package com.scorenow.scorenow_api.global.websocket.interceptor;
+
+import java.security.Principal;
+import java.util.regex.Pattern;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+
+@Component
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+	private static final Pattern CHAT_SEND_DESTINATION = Pattern.compile("^/pub/matches/\\d+/chat/messages$");
+	private final StompJwtAuthenticator stompJwtAuthenticator;
+
+	private static final Pattern CHAT_SUBSCRIBE_DESTINATION = Pattern.compile("^/sub/matches/\\d+/chat/messages$");
+
+	public StompAuthChannelInterceptor(StompJwtAuthenticator stompJwtAuthenticator) {
+		this.stompJwtAuthenticator = stompJwtAuthenticator;
+	}
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+		StompCommand command = accessor.getCommand();
+
+		if (StompCommand.CONNECT.equals(command)) {
+			stompJwtAuthenticator.authenticateIfTokenExists(accessor);
+		} else if (StompCommand.SEND.equals(command)) {
+			validateDestination(accessor.getDestination(),CHAT_SEND_DESTINATION);
+			validateAuthenticatedUser(accessor.getUser());
+		} else if (StompCommand.SUBSCRIBE.equals(command)) {
+			validateDestination(accessor.getDestination(),CHAT_SUBSCRIBE_DESTINATION);
+		}
+
+		return message;
+	}
+
+	private void validateDestination(String destination, Pattern allowedPattern) {
+		if (destination == null || !allowedPattern.matcher(destination).matches()) {
+			throw new BusinessException(ErrorCode.INVALID_PARAMETER);
+		}
+	}
+
+	private void validateAuthenticatedUser(Principal user) {
+		if (user == null) {
+			throw new BusinessException(ErrorCode.CHAT_SEND_AUTH_REQUIRED);
+		}
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/global/websocket/interceptor/StompJwtAuthenticator.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/websocket/interceptor/StompJwtAuthenticator.java
@@ -1,0 +1,44 @@
+package com.scorenow.scorenow_api.global.websocket.interceptor;
+
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import com.scorenow.scorenow_api.domain.user.jwt.JwtProvider;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import com.scorenow.scorenow_api.global.websocket.principal.StompPrincipal;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StompJwtAuthenticator {
+
+	private final JwtProvider jwtProvider;
+
+	public void authenticateIfTokenExists(StompHeaderAccessor accessor) {
+		String authorization = accessor.getFirstNativeHeader("Authorization");
+
+		if (authorization == null || authorization.isBlank()) {
+			return;
+		}
+
+		if (!authorization.startsWith("Bearer ")) {
+			throw new BusinessException(ErrorCode.INVALID_PARAMETER);
+		}
+
+		String token = authorization.substring(7);
+
+		if (!jwtProvider.validateToken(token)) {
+			throw new BusinessException(ErrorCode.TOKEN_INVALID);
+		}
+
+		if (!jwtProvider.isAccessToken(token)) {
+			throw new BusinessException(ErrorCode.ACCESS_TOKEN_REQUIRED);
+		}
+
+		Long userId = jwtProvider.getUserId(token);
+
+		accessor.setUser(new StompPrincipal(userId));
+	}
+}

--- a/src/main/java/com/scorenow/scorenow_api/global/websocket/principal/StompPrincipal.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/websocket/principal/StompPrincipal.java
@@ -1,0 +1,21 @@
+package com.scorenow.scorenow_api.global.websocket.principal;
+
+import java.security.Principal;
+
+public class StompPrincipal implements Principal {
+
+	private final Long userId;
+
+	public StompPrincipal(Long userId) {
+		this.userId = userId;
+	}
+
+	@Override
+	public String getName() {
+		return String.valueOf(userId);
+	}
+
+	public Long getUserId() {
+		return userId;
+	}
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/chat/controller/ChatMessageControllerTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/chat/controller/ChatMessageControllerTest.java
@@ -1,0 +1,114 @@
+package com.scorenow.scorenow_api.domain.chat.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageRequest;
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageResponse;
+import com.scorenow.scorenow_api.domain.chat.service.ChatMessageService;
+import com.scorenow.scorenow_api.global.dto.ApiResponse;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import com.scorenow.scorenow_api.global.websocket.principal.StompPrincipal;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageControllerTest {
+
+	@Mock
+	private ChatMessageService chatMessageService;
+
+	@Mock
+	private SimpMessagingTemplate messagingTemplate;
+
+	@InjectMocks
+	private ChatMessageController chatMessageController;
+
+	@Test
+	void sendMessage_creates_message_and_publishes_response() {
+		Long matchId = 1L;
+		Long userId = 10L;
+		ChatMessageRequest request = request("hello score now");
+		ChatMessageResponse response = ChatMessageResponse.builder()
+			.matchId(matchId)
+			.senderNickname("score-user")
+			.message("hello score now")
+			.createdAt(LocalDateTime.of(2026, 6, 30, 20, 15))
+			.build();
+
+		given(chatMessageService.createMessage(matchId, userId, request)).willReturn(response);
+
+		chatMessageController.sendMessage(matchId, request, new StompPrincipal(userId));
+
+		then(messagingTemplate).should()
+			.convertAndSend("/sub/matches/" + matchId + "/chat/messages", response);
+	}
+
+	@Test
+	void sendMessage_fails_when_principal_is_not_stomp_principal() {
+		Principal principal = () -> "not-stomp-principal";
+
+		assertThatExceptionOfType(BusinessException.class)
+			.isThrownBy(() -> chatMessageController.sendMessage(1L, request("hello"), principal))
+			.satisfies(exception -> assertThat(exception.getErrorCode())
+				.isEqualTo(ErrorCode.CHAT_SEND_AUTH_REQUIRED));
+		verifyNoInteractions(chatMessageService, messagingTemplate);
+	}
+
+	@Test
+	void sendMessage_fails_when_request_is_null() {
+		assertThatExceptionOfType(BusinessException.class)
+			.isThrownBy(() -> chatMessageController.sendMessage(1L, null, new StompPrincipal(10L)))
+			.satisfies(exception -> assertThat(exception.getErrorCode())
+				.isEqualTo(ErrorCode.CHAT_MESSAGE_INVALID));
+		verifyNoInteractions(chatMessageService, messagingTemplate);
+	}
+
+	@Test
+	void sendMessage_fails_when_request_message_is_null() {
+		ChatMessageRequest request = request(null);
+
+		assertThatExceptionOfType(BusinessException.class)
+			.isThrownBy(() -> chatMessageController.sendMessage(1L, request, new StompPrincipal(10L)))
+			.satisfies(exception -> assertThat(exception.getErrorCode())
+				.isEqualTo(ErrorCode.CHAT_MESSAGE_INVALID));
+		verifyNoInteractions(chatMessageService, messagingTemplate);
+	}
+
+	@Test
+	void handleBusinessException_sends_error_response_to_user_queue() {
+		ArgumentCaptor<Object> responseCaptor = ArgumentCaptor.forClass(Object.class);
+		BusinessException exception = new BusinessException(ErrorCode.CHAT_MESSAGE_INVALID);
+
+		chatMessageController.handleBusinessException(exception, new StompPrincipal(10L));
+
+		then(messagingTemplate).should()
+			.convertAndSendToUser(eq("10"), eq("/queue/errors"), responseCaptor.capture());
+		ApiResponse<?> response = (ApiResponse<?>) responseCaptor.getValue();
+
+		assertThat(response.isSuccess()).isFalse();
+		assertThat(response.getError().getCode()).isEqualTo(ErrorCode.CHAT_MESSAGE_INVALID.getCode());
+		assertThat(response.getError().getMessage()).isEqualTo(ErrorCode.CHAT_MESSAGE_INVALID.getMessage());
+	}
+
+	private ChatMessageRequest request(String message) {
+		ChatMessageRequest request = new ChatMessageRequest();
+		ReflectionTestUtils.setField(request, "message", message);
+		return request;
+	}
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/chat/entity/ChatMessageTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/chat/entity/ChatMessageTest.java
@@ -1,0 +1,65 @@
+package com.scorenow.scorenow_api.domain.chat.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.user.entity.User;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+
+class ChatMessageTest {
+
+	@Test
+	void create_trims_message_and_snapshots_sender_nickname() {
+		Match match = Match.builder().id(1L).build();
+		User sender = User.builder().id(10L).nickname("score-user").build();
+
+		ChatMessage chatMessage = ChatMessage.create(match, sender, "  hello score now  ");
+
+		assertThat(chatMessage.getMatchId()).isEqualTo(1L);
+		assertThat(chatMessage.getUserId()).isEqualTo(10L);
+		assertThat(chatMessage.getSenderNickname()).isEqualTo("score-user");
+		assertThat(chatMessage.getMessage()).isEqualTo("hello score now");
+	}
+
+	@Test
+	void create_fails_when_match_is_null() {
+		User sender = User.builder().id(10L).nickname("score-user").build();
+
+		assertThatExceptionOfType(BusinessException.class)
+			.isThrownBy(() -> ChatMessage.create(null, sender, "message"))
+			.satisfies(exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MATCH_NOT_FOUND));
+	}
+
+	@Test
+	void create_fails_when_sender_is_null() {
+		Match match = Match.builder().id(1L).build();
+
+		assertThatExceptionOfType(BusinessException.class)
+			.isThrownBy(() -> ChatMessage.create(match, null, "message"))
+			.satisfies(exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
+	}
+
+	@Test
+	void create_fails_when_message_is_blank() {
+		Match match = Match.builder().id(1L).build();
+		User sender = User.builder().id(10L).nickname("score-user").build();
+
+		assertThatExceptionOfType(BusinessException.class)
+			.isThrownBy(() -> ChatMessage.create(match, sender, "   "))
+			.satisfies(exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHAT_MESSAGE_INVALID));
+	}
+
+	@Test
+	void create_fails_when_message_length_exceeds_limit_after_trim() {
+		Match match = Match.builder().id(1L).build();
+		User sender = User.builder().id(10L).nickname("score-user").build();
+		String overLimitMessage = " " + "a".repeat(1001) + " ";
+
+		assertThatExceptionOfType(BusinessException.class)
+			.isThrownBy(() -> ChatMessage.create(match, sender, overLimitMessage))
+			.satisfies(exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHAT_MESSAGE_LENGTH_EXCEEDED));
+	}
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/chat/service/ChatHistoryServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/chat/service/ChatHistoryServiceTest.java
@@ -1,0 +1,126 @@
+package com.scorenow.scorenow_api.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageResponse;
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageSliceResponse;
+import com.scorenow.scorenow_api.domain.chat.entity.ChatMessage;
+import com.scorenow.scorenow_api.domain.chat.repository.ChatMessageRepository;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.service.MatchReferenceService;
+import com.scorenow.scorenow_api.domain.user.entity.User;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class ChatHistoryServiceTest {
+
+	@Mock
+	private ChatMessageRepository chatMessageRepository;
+
+	@Mock
+	private MatchReferenceService matchReferenceService;
+
+	@InjectMocks
+	private ChatHistoryService chatHistoryService;
+
+	@Test
+	void getMessages_without_cursor_returns_latest_messages_with_next_cursor() {
+		Long matchId = 1L;
+		int size = 2;
+		given(matchReferenceService.requireMatch(matchId)).willReturn(Match.builder().id(matchId).build());
+		given(chatMessageRepository.findByMatch_IdOrderByIdDesc(matchId, PageRequest.of(0, size + 1)))
+			.willReturn(List.of(
+				message(5L, matchId, "message-5"),
+				message(4L, matchId, "message-4"),
+				message(3L, matchId, "message-3")
+			));
+
+		ChatMessageSliceResponse response = chatHistoryService.getMessages(matchId, null, size);
+
+		assertThat(response.getMessages()).hasSize(2);
+		assertThat(response.getMessages()).extracting(ChatMessageResponse::getMessage)
+			.containsExactly("message-5", "message-4");
+		assertThat(response.getNextCursor()).isEqualTo(4L);
+		assertThat(response.isHasNext()).isTrue();
+		then(chatMessageRepository).should(never())
+			.findByMatch_IdAndIdLessThanOrderByIdDesc(anyLong(), anyLong(), any(Pageable.class));
+	}
+
+	@Test
+	void getMessages_with_cursor_returns_older_messages() {
+		Long matchId = 1L;
+		Long cursor = 5L;
+		int size = 2;
+		given(matchReferenceService.requireMatch(matchId)).willReturn(Match.builder().id(matchId).build());
+		given(chatMessageRepository.findByMatch_IdAndIdLessThanOrderByIdDesc(matchId, cursor, PageRequest.of(0, size + 1)))
+			.willReturn(List.of(
+				message(4L, matchId, "message-4"),
+				message(3L, matchId, "message-3")
+			));
+
+		ChatMessageSliceResponse response = chatHistoryService.getMessages(matchId, cursor, size);
+
+		assertThat(response.getMessages()).hasSize(2);
+		assertThat(response.getMessages()).extracting(ChatMessageResponse::getMessage)
+			.containsExactly("message-4", "message-3");
+		assertThat(response.getNextCursor()).isEqualTo(3L);
+		assertThat(response.isHasNext()).isFalse();
+		then(chatMessageRepository).should(never()).findByMatch_IdOrderByIdDesc(anyLong(), any(Pageable.class));
+	}
+
+	@Test
+	void getMessages_returns_null_cursor_when_history_is_empty() {
+		Long matchId = 1L;
+		int size = 30;
+		given(matchReferenceService.requireMatch(matchId)).willReturn(Match.builder().id(matchId).build());
+		given(chatMessageRepository.findByMatch_IdOrderByIdDesc(matchId, PageRequest.of(0, size + 1)))
+			.willReturn(List.of());
+
+		ChatMessageSliceResponse response = chatHistoryService.getMessages(matchId, null, size);
+
+		assertThat(response.getMessages()).isEmpty();
+		assertThat(response.getNextCursor()).isNull();
+		assertThat(response.isHasNext()).isFalse();
+	}
+
+	@Test
+	void getMessages_fails_when_size_is_less_than_one() {
+		assertThatExceptionOfType(BusinessException.class)
+			.isThrownBy(() -> chatHistoryService.getMessages(1L, null, 0))
+			.satisfies(exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_PARAMETER));
+		verifyNoInteractions(matchReferenceService, chatMessageRepository);
+	}
+
+	@Test
+	void getMessages_fails_when_size_exceeds_maximum() {
+		assertThatExceptionOfType(BusinessException.class)
+			.isThrownBy(() -> chatHistoryService.getMessages(1L, null, 101))
+			.satisfies(exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_PARAMETER));
+		verifyNoInteractions(matchReferenceService, chatMessageRepository);
+	}
+
+	private ChatMessage message(Long id, Long matchId, String content) {
+		Match match = Match.builder().id(matchId).build();
+		User user = User.builder().id(10L).nickname("score-user").build();
+		ChatMessage chatMessage = ChatMessage.create(match, user, content);
+		ReflectionTestUtils.setField(chatMessage, "id", id);
+		ReflectionTestUtils.setField(chatMessage, "createdAt", LocalDateTime.of(2026, 6, 2, 20, id.intValue()));
+		return chatMessage;
+	}
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/chat/service/ChatMessageServiceTest.java
@@ -1,0 +1,97 @@
+package com.scorenow.scorenow_api.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageRequest;
+import com.scorenow.scorenow_api.domain.chat.dto.ChatMessageResponse;
+import com.scorenow.scorenow_api.domain.chat.entity.ChatMessage;
+import com.scorenow.scorenow_api.domain.chat.repository.ChatMessageRepository;
+import com.scorenow.scorenow_api.domain.match.entity.Match;
+import com.scorenow.scorenow_api.domain.match.service.MatchReferenceService;
+import com.scorenow.scorenow_api.domain.user.entity.User;
+import com.scorenow.scorenow_api.domain.user.service.UserReferenceService;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceTest {
+
+	@Mock
+	private MatchReferenceService matchReferenceService;
+
+	@Mock
+	private ChatMessageRepository chatMessageRepository;
+
+	@Mock
+	private UserReferenceService userReferenceService;
+
+	@InjectMocks
+	private ChatMessageService chatMessageService;
+
+	@Test
+	void createMessage_saves_chat_message_and_returns_response() {
+		Long matchId = 1L;
+		Long userId = 10L;
+		Match match = Match.builder().id(matchId).build();
+		User user = User.builder().id(userId).nickname("score-user").build();
+		LocalDateTime createdAt = LocalDateTime.of(2026, 6, 2, 20, 15);
+
+		given(matchReferenceService.requireMatch(matchId)).willReturn(match);
+		given(userReferenceService.requireActiveUser(userId)).willReturn(user);
+		given(chatMessageRepository.save(any(ChatMessage.class))).willAnswer(invocation -> {
+			ChatMessage savedMessage = invocation.getArgument(0);
+			ReflectionTestUtils.setField(savedMessage, "id", 100L);
+			ReflectionTestUtils.setField(savedMessage, "createdAt", createdAt);
+			return savedMessage;
+		});
+
+		ChatMessageResponse response = chatMessageService.createMessage(matchId, userId, request("  hello score now  "));
+
+		ArgumentCaptor<ChatMessage> captor = ArgumentCaptor.forClass(ChatMessage.class);
+		then(chatMessageRepository).should().save(captor.capture());
+		ChatMessage savedMessage = captor.getValue();
+
+		assertThat(savedMessage.getMatchId()).isEqualTo(matchId);
+		assertThat(savedMessage.getUserId()).isEqualTo(userId);
+		assertThat(savedMessage.getSenderNickname()).isEqualTo("score-user");
+		assertThat(savedMessage.getMessage()).isEqualTo("hello score now");
+		assertThat(response.getMatchId()).isEqualTo(matchId);
+		assertThat(response.getSenderNickname()).isEqualTo("score-user");
+		assertThat(response.getMessage()).isEqualTo("hello score now");
+		assertThat(response.getCreatedAt()).isEqualTo(createdAt);
+	}
+
+	@Test
+	void createMessage_does_not_save_blank_message() {
+		Long matchId = 1L;
+		Long userId = 10L;
+		Match match = Match.builder().id(matchId).build();
+		User user = User.builder().id(userId).nickname("score-user").build();
+
+		given(matchReferenceService.requireMatch(matchId)).willReturn(match);
+		given(userReferenceService.requireActiveUser(userId)).willReturn(user);
+
+		assertThatExceptionOfType(BusinessException.class)
+			.isThrownBy(() -> chatMessageService.createMessage(matchId, userId, request("  ")))
+			.satisfies(exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHAT_MESSAGE_INVALID));
+		then(chatMessageRepository).should(never()).save(any(ChatMessage.class));
+	}
+
+	private ChatMessageRequest request(String message) {
+		ChatMessageRequest request = new ChatMessageRequest();
+		ReflectionTestUtils.setField(request, "message", message);
+		return request;
+	}
+}


### PR DESCRIPTION
#️⃣ Issue Number
[✨ Feat: 경기 채팅 기능 개발 #100](https://github.com/score-now-org/score-now-server/issues/100)

📝 요약(Summary)
경기별 실시간 채팅 기능을 추가했습니다.

STOMP WebSocket 기반으로 경기 채팅 메시지를 송수신할 수 있도록 설정하고, 채팅 메시지를 DB에 저장하도록 구현했습니다.

또한 경기별 채팅 내역을 커서 기반으로 조회할 수 있는 API를 추가하고, 채팅 메시지 생성/검증/히스토리 조회에 대한 테스트를 작성했습니다.

🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

💬 공유사항 to 리뷰어
채팅 기능은 아래처럼 동작합니다.

WebSocket 연결 엔드포인트
→ `/ws`

메시지 발행
→ `/pub/matches/{matchId}/chat/messages`

메시지 구독
→ `/sub/matches/{matchId}/chat/messages`

채팅 내역 조회
→ `GET /api/v1/chat/{matchId}/history`

인증 정책
→ WebSocket CONNECT 시 Authorization 헤더에 AccessToken이 있으면 사용자 인증 처리  
→ 채팅 메시지 SEND는 로그인 사용자만 가능  
→ SUBSCRIBE는 지정된 경기 채팅 경로만 허용  

저장 정책
→ 채팅 메시지는 `chat_messages` 테이블에 저장  
→ 메시지 저장 시 sender nickname을 함께 스냅샷으로 저장  
→ 공백 메시지와 1000자 초과 메시지는 저장하지 않음  

테스트 추가
→ `ChatMessageTest`  
→ `ChatMessageServiceTest`  
→ `ChatHistoryServiceTest`

✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

테스트 결과
- `.\gradlew.bat test --tests "com.scorenow.scorenow_api.domain.chat.*" --rerun-tasks` 성공