### PR TITLE
feat: 관리자 페이지 순위 관리 기능 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ gcp-key.json
 ### Local config ###
 src/main/resources/application.yml
 .env
+/docs/
+/logs/

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonApiDocs.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonApiDocs.java
@@ -1,0 +1,35 @@
+package com.scorenow.scorenow_api.domain.league.controller;
+
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonCreateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonSearchCondition;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonUpdateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonResponse;
+import com.scorenow.scorenow_api.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@Tag(name = "Admin League Season API", description = "관리자 리그 시즌 관리 API")
+public interface AdminLeagueSeasonApiDocs {
+
+    @Operation(summary = "리그 시즌 생성", description = "관리자 페이지에서 리그에 시즌 정보를 등록합니다. 현재 시즌으로 등록하면 기존 현재 시즌은 해제됩니다.")
+    ApiResponse<Void> createLeagueSeason(
+            @Parameter(description = "생성할 리그 시즌 정보", required = true) LeagueSeasonCreateRequest request);
+
+    @Operation(summary = "리그 시즌 검색", description = "리그 ID, 리그명 조건으로 리그 시즌 목록을 페이징 조회합니다. 조건이 없으면 전체 리그 시즌을 조회합니다.")
+    ApiResponse<Page<AdminLeagueSeasonResponse>> searchLeagueSeasons(
+            @ParameterObject LeagueSeasonSearchCondition condition,
+            @ParameterObject Pageable pageable);
+
+    @Operation(summary = "리그 시즌 수정", description = "리그 시즌 ID 기준으로 시즌 정보를 부분 수정합니다. 요청에 포함된 필드만 변경됩니다.")
+    ApiResponse<Void> updateLeagueSeason(
+            @Parameter(description = "수정할 리그 시즌 ID", required = true, example = "1") Long leagueSeasonId,
+            @Parameter(description = "수정할 리그 시즌 정보", required = true) LeagueSeasonUpdateRequest request);
+
+    @Operation(summary = "리그 시즌 삭제", description = "리그 시즌 ID 기준으로 시즌을 비활성화합니다.")
+    ApiResponse<Void> deleteLeagueSeason(
+            @Parameter(description = "삭제할 리그 시즌 ID", required = true, example = "1") Long leagueSeasonId);
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonController.java
@@ -1,0 +1,52 @@
+package com.scorenow.scorenow_api.domain.league.controller;
+
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonCreateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonSearchCondition;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonUpdateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonResponse;
+import com.scorenow.scorenow_api.domain.league.service.AdminLeagueSeasonService;
+import com.scorenow.scorenow_api.global.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/admin/league-seasons")
+public class AdminLeagueSeasonController implements AdminLeagueSeasonApiDocs {
+
+    private final AdminLeagueSeasonService adminLeagueSeasonService;
+
+    @PostMapping
+    public ApiResponse<Void> createLeagueSeason(@RequestBody @Valid LeagueSeasonCreateRequest request) {
+        adminLeagueSeasonService.createLeagueSeason(request);
+        return ApiResponse.success();
+    }
+
+    @GetMapping
+    public ApiResponse<Page<AdminLeagueSeasonResponse>> searchLeagueSeasons(
+            @ModelAttribute LeagueSeasonSearchCondition condition,
+            Pageable pageable) {
+
+        return ApiResponse.success(
+                adminLeagueSeasonService.searchLeagueSeasons(condition, pageable)
+        );
+    }
+
+    @PatchMapping("/{leagueSeasonId}")
+    public ApiResponse<Void> updateLeagueSeason(
+            @PathVariable Long leagueSeasonId,
+            @RequestBody @Valid LeagueSeasonUpdateRequest request) {
+
+        adminLeagueSeasonService.updateLeagueSeason(leagueSeasonId, request);
+        return ApiResponse.success();
+    }
+
+    @DeleteMapping("/{leagueSeasonId}")
+    public ApiResponse<Void> deleteLeagueSeason(@PathVariable Long leagueSeasonId) {
+        adminLeagueSeasonService.deleteLeagueSeason(leagueSeasonId);
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonStandingsApiDocs.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonStandingsApiDocs.java
@@ -2,6 +2,7 @@ package com.scorenow.scorenow_api.domain.league.controller;
 
 import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsCreateRequest;
 import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsSearchCondition;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsTypeUpdateRequest;
 import com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonStandingsResponse;
 import com.scorenow.scorenow_api.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,7 +25,19 @@ public interface AdminLeagueSeasonStandingsApiDocs {
             @ParameterObject LeagueSeasonStandingsSearchCondition condition,
             @ParameterObject Pageable pageable);
 
-    @Operation(summary = "리그 시즌 순위 관리 삭제", description = "리그 시즌 ID 기준으로 순위 관리 설정을 삭제합니다. 외부 데이터 타입이면 저장된 순위 문서도 함께 삭제합니다.")
+    @Operation(
+            summary = "리그 시즌 순위 관리 타입 수정",
+            description = "리그 시즌 순위 관리 타입을 IMAGE 또는 EXTERNAL_DATA로 변경합니다. 기존 이미지 URL과 외부 순위 문서는 삭제하지 않습니다."
+    )
+    ApiResponse<Void> updateLeagueSeasonStandingsType(
+            @Parameter(description = "수정할 순위 관리 설정의 리그 시즌 ID", required = true, example = "1")
+            Long leagueSeasonId,
+
+            @Parameter(description = "변경할 리그 시즌 순위 관리 타입", required = true)
+            LeagueSeasonStandingsTypeUpdateRequest request
+    );
+
+    @Operation(summary = "리그 시즌 순위 관리 삭제", description = "리그 시즌 ID 기준으로 순위 관리 설정을 삭제합니다. 타입과 무관하게 연결된 외부 순위 문서도 함께 삭제합니다.")
     ApiResponse<Void> deleteLeagueSeasonStandings(
             @Parameter(description = "삭제할 순위 관리 설정의 리그 시즌 ID", required = true, example = "1") Long leagueSeasonId);
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonStandingsApiDocs.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonStandingsApiDocs.java
@@ -1,0 +1,39 @@
+package com.scorenow.scorenow_api.domain.league.controller;
+
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsCreateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsSearchCondition;
+import com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonStandingsResponse;
+import com.scorenow.scorenow_api.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Admin League Season Standings API", description = "관리자 리그 시즌 순위 관리 API")
+public interface AdminLeagueSeasonStandingsApiDocs {
+
+    @Operation(summary = "리그 시즌 순위 관리 등록", description = "리그 시즌에 순위 관리 방식을 등록합니다. 시즌 하나에는 하나의 순위 관리 설정만 등록할 수 있습니다.")
+    ApiResponse<Void> createLeagueSeasonStandings(
+            @Parameter(description = "등록할 리그 시즌 순위 관리 정보", required = true) LeagueSeasonStandingsCreateRequest request);
+
+    @Operation(summary = "리그 시즌 순위 관리 검색", description = "리그 ID, 리그명 조건으로 리그 시즌 순위 관리 목록을 페이징 조회합니다. 조건이 없으면 전체 목록을 조회합니다.")
+    ApiResponse<Page<AdminLeagueSeasonStandingsResponse>> searchLeagueSeasonStandings(
+            @ParameterObject LeagueSeasonStandingsSearchCondition condition,
+            @ParameterObject Pageable pageable);
+
+    @Operation(summary = "리그 시즌 순위 관리 삭제", description = "리그 시즌 ID 기준으로 순위 관리 설정을 삭제합니다. 외부 데이터 타입이면 저장된 순위 문서도 함께 삭제합니다.")
+    ApiResponse<Void> deleteLeagueSeasonStandings(
+            @Parameter(description = "삭제할 순위 관리 설정의 리그 시즌 ID", required = true, example = "1") Long leagueSeasonId);
+
+    @Operation(summary = "리그 시즌 순위 이미지 업로드", description = "이미지 타입으로 관리되는 리그 시즌 순위 이미지를 업로드합니다.")
+    ApiResponse<Void> uploadLeagueSeasonStandingsImage(
+            @Parameter(description = "이미지를 업로드할 리그 시즌 ID", required = true, example = "1") Long leagueSeasonId,
+            @Parameter(description = "업로드할 순위 이미지", required = true) MultipartFile image);
+
+    @Operation(summary = "리그 시즌 순위 외부 데이터 동기화", description = "외부 데이터 타입으로 관리되는 리그 시즌 순위를 즉시 동기화합니다.")
+    ApiResponse<Void> syncLeagueSeasonStandingsData(
+            @Parameter(description = "동기화할 리그 시즌 ID", required = true, example = "1") Long leagueSeasonId);
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonStandingsController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonStandingsController.java
@@ -1,0 +1,58 @@
+package com.scorenow.scorenow_api.domain.league.controller;
+
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsCreateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsSearchCondition;
+import com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonStandingsResponse;
+import com.scorenow.scorenow_api.domain.league.service.AdminLeagueSeasonStandingsService;
+import com.scorenow.scorenow_api.global.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/admin/league-season-standings")
+public class AdminLeagueSeasonStandingsController implements AdminLeagueSeasonStandingsApiDocs {
+
+    private final AdminLeagueSeasonStandingsService adminLeagueSeasonStandingsService;
+
+    @PostMapping
+    public ApiResponse<Void> createLeagueSeasonStandings(@RequestBody @Valid LeagueSeasonStandingsCreateRequest request) {
+        adminLeagueSeasonStandingsService.createLeagueSeasonStandings(request);
+        return ApiResponse.success();
+    }
+
+    @GetMapping
+    public ApiResponse<Page<AdminLeagueSeasonStandingsResponse>> searchLeagueSeasonStandings(
+            @ModelAttribute LeagueSeasonStandingsSearchCondition condition,
+            Pageable pageable) {
+
+        return ApiResponse.success(
+                adminLeagueSeasonStandingsService.searchLeagueSeasonStandings(condition, pageable)
+        );
+    }
+
+    @DeleteMapping("/{leagueSeasonId}")
+    public ApiResponse<Void> deleteLeagueSeasonStandings(@PathVariable Long leagueSeasonId) {
+        adminLeagueSeasonStandingsService.deleteLeagueSeasonStandings(leagueSeasonId);
+        return ApiResponse.success();
+    }
+
+    @PostMapping("/{leagueSeasonId}/image")
+    public ApiResponse<Void> uploadLeagueSeasonStandingsImage(
+            @PathVariable Long leagueSeasonId,
+            @RequestPart("image") MultipartFile image) {
+
+        adminLeagueSeasonStandingsService.uploadLeagueSeasonStandingsImage(leagueSeasonId, image);
+        return ApiResponse.success();
+    }
+
+    @PostMapping("/{leagueSeasonId}/sync")
+    public ApiResponse<Void> syncLeagueSeasonStandingsData(@PathVariable Long leagueSeasonId) {
+        adminLeagueSeasonStandingsService.syncLeagueSeasonStandingsData(leagueSeasonId);
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonStandingsController.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/controller/AdminLeagueSeasonStandingsController.java
@@ -2,6 +2,7 @@ package com.scorenow.scorenow_api.domain.league.controller;
 
 import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsCreateRequest;
 import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsSearchCondition;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsTypeUpdateRequest;
 import com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonStandingsResponse;
 import com.scorenow.scorenow_api.domain.league.service.AdminLeagueSeasonStandingsService;
 import com.scorenow.scorenow_api.global.dto.ApiResponse;
@@ -33,6 +34,15 @@ public class AdminLeagueSeasonStandingsController implements AdminLeagueSeasonSt
         return ApiResponse.success(
                 adminLeagueSeasonStandingsService.searchLeagueSeasonStandings(condition, pageable)
         );
+    }
+
+    @PatchMapping("/{leagueSeasonId}/type")
+    public ApiResponse<Void> updateLeagueSeasonStandingsType(
+            @PathVariable Long leagueSeasonId,
+            @RequestBody @Valid LeagueSeasonStandingsTypeUpdateRequest request) {
+
+        adminLeagueSeasonStandingsService.updateLeagueSeasonStandingsType(leagueSeasonId, request);
+        return ApiResponse.success();
     }
 
     @DeleteMapping("/{leagueSeasonId}")

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/document/LeagueSeasonStandingsDataDocument.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/document/LeagueSeasonStandingsDataDocument.java
@@ -1,0 +1,94 @@
+package com.scorenow.scorenow_api.domain.league.document;
+
+import com.scorenow.scorenow_api.domain.common.enums.DataOrigin;
+import com.scorenow.scorenow_api.global.entity.BaseDocument;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@Document(collection = "league_season_standing_data")
+public class LeagueSeasonStandingsDataDocument extends BaseDocument {
+
+    @Id
+    private String id;
+
+    /* League + LeagueExternalMapping */
+    private Long leagueId;
+    private String apiLeagueId;
+    private DataOrigin dataOrigin;
+
+    /* LeagueSeason */
+    @Indexed(   // TODO: 추후 운영에서 인덱스 생성되는지 확인 필요
+            name = "uk_league_season_standing_data_document",
+            unique = true
+    )
+    private Long leagueSeasonId;
+
+    /* 외부 API 응답 */
+    private String externalSeasonName;
+    private Long externalSeasonStartAt; // Unix Timestamp
+    private Long externalSeasonEndAt;   // Unix Timestamp
+
+    /* 순위 정보 */
+    private StandingsTable standingsTable;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class StandingsTable {
+        private String name;
+        private String groupName;
+        private Integer currentRound;
+        private Integer maxRounds;
+        private List<StandingsRow> rows;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class StandingsRow {
+        private Integer position;
+        private Integer positionChange;
+
+        private Integer played;
+        private Integer win;
+        private Integer draw;
+        private Integer loss;
+
+        private Integer goalsFor;       // 득점
+        private Integer goalsAgainst;   // 실점
+        private Integer goalDifference; // 득실차
+        private Integer points;         // 승점
+
+        private Promotion promotion;
+        private Team team;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Promotion {
+        private String name;
+        private String shortName;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Team {
+        private String apiTeamId;
+        private String name;
+        private String imageId;
+        private String countryCode;
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/document/LeagueSeasonStandingsDataDocument.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/document/LeagueSeasonStandingsDataDocument.java
@@ -7,7 +7,6 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/LeagueSeasonStandingsSyncTarget.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/LeagueSeasonStandingsSyncTarget.java
@@ -1,0 +1,22 @@
+package com.scorenow.scorenow_api.domain.league.dto;
+
+import com.scorenow.scorenow_api.domain.common.enums.DataOrigin;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LeagueSeasonStandingsSyncTarget {
+
+    private final Long leagueSeasonStandingsId;
+    private final Long leagueSeasonId;
+    private final Long leagueId;
+    private final DataOrigin dataOrigin;
+    private final String apiLeagueId;
+
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/LeagueSeasonStandingsSyncTarget.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/LeagueSeasonStandingsSyncTarget.java
@@ -6,8 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
-
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonCreateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonCreateRequest.java
@@ -1,0 +1,34 @@
+package com.scorenow.scorenow_api.domain.league.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Schema(description = "관리자 리그 시즌 생성 요청")
+@Getter
+@NoArgsConstructor
+public class LeagueSeasonCreateRequest {
+
+    @NotNull(message = "리그 ID 는 필수 입니다.")
+    @Schema(description = "시즌을 등록할 리그 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Long leagueId;
+
+    @NotBlank(message = "시즌명은 필수 입니다.")
+    @Schema(description = "시즌명", example = "2025/26", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String seasonName;
+
+    @NotNull(message = "시즌 시작일은 필수 입니다.")
+    @Schema(description = "시즌 시작일", example = "2025-08-01", requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDate seasonStartAt;
+
+    @NotNull(message = "시즌 종료일은 필수 입니다.")
+    @Schema(description = "시즌 종료일", example = "2026-05-31", requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDate seasonEndAt;
+
+    @Schema(description = "현재 시즌 여부. true이면 기존 현재 시즌은 해제됩니다.", example = "true")
+    private boolean isCurrent;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonSearchCondition.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonSearchCondition.java
@@ -1,0 +1,17 @@
+package com.scorenow.scorenow_api.domain.league.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Schema(description = "관리자 리그 시즌 검색 조건")
+@Getter
+@Setter
+public class LeagueSeasonSearchCondition {
+
+    @Schema(description = "리그 ID", example = "1")
+    private Long leagueId;
+
+    @Schema(description = "리그명 검색어. 한글명/영문명 기준으로 검색합니다.", example = "Premier")
+    private String leagueName;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonStandingsCreateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonStandingsCreateRequest.java
@@ -1,0 +1,21 @@
+package com.scorenow.scorenow_api.domain.league.dto.request;
+
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeasonStandingsType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "관리자 리그 시즌 순위 관리 등록 요청")
+@Getter
+@NoArgsConstructor
+public class LeagueSeasonStandingsCreateRequest {
+
+    @NotNull(message = "리그 시즌 ID는 필수입니다.")
+    @Schema(description = "순위 관리를 등록할 리그 시즌 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Long leagueSeasonId;
+
+    @NotNull(message = "리그 시즌 순위 관리 타입은 필수입니다.")
+    @Schema(description = "리그 시즌 순위 관리 타입", example = "EXTERNAL_DATA", allowableValues = {"IMAGE", "EXTERNAL_DATA"}, requiredMode = Schema.RequiredMode.REQUIRED)
+    private LeagueSeasonStandingsType standingsType;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonStandingsSearchCondition.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonStandingsSearchCondition.java
@@ -1,0 +1,17 @@
+package com.scorenow.scorenow_api.domain.league.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Schema(description = "관리자 리그 시즌 순위 관리 검색 조건")
+@Getter
+@Setter
+public class LeagueSeasonStandingsSearchCondition {
+
+    @Schema(description = "리그 ID", example = "1")
+    private Long leagueId;
+
+    @Schema(description = "리그명 검색어. 한글명/영문명 기준으로 검색합니다.", example = "Premier")
+    private String leagueName;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonStandingsTypeUpdateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonStandingsTypeUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.scorenow.scorenow_api.domain.league.dto.request;
+
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeasonStandingsType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "리그 시즌 순위 관리 타입 수정 요청")
+public class LeagueSeasonStandingsTypeUpdateRequest {
+
+    @NotNull(message = "리그 순위 관리 타입은 필수입니다.")
+    @Schema(description = "리그 순위 관리 타입", example = "IMAGE")
+    private LeagueSeasonStandingsType standingsType;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonUpdateRequest.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/request/LeagueSeasonUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.scorenow.scorenow_api.domain.league.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Schema(description = "관리자 리그 시즌 수정 요청")
+@Getter
+@NoArgsConstructor
+public class LeagueSeasonUpdateRequest {
+
+    @Schema(description = "시즌명. null이면 변경하지 않습니다.", example = "2025/26")
+    private String seasonName;
+
+    @Schema(description = "시즌 시작일. null이면 변경하지 않습니다.", example = "2025-08-01")
+    private LocalDate seasonStartAt;
+
+    @Schema(description = "시즌 종료일. null이면 변경하지 않습니다.", example = "2026-05-31")
+    private LocalDate seasonEndAt;
+
+    @Schema(description = "현재 시즌 여부. null이면 변경하지 않습니다. true이면 기존 현재 시즌은 해제됩니다.", example = "true")
+    private Boolean isCurrent;
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/response/AdminLeagueSeasonResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/response/AdminLeagueSeasonResponse.java
@@ -1,0 +1,54 @@
+package com.scorenow.scorenow_api.domain.league.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Schema(description = "관리자 리그 시즌 응답")
+@Getter
+@NoArgsConstructor
+public class AdminLeagueSeasonResponse {
+
+    /* 리그 정보 */
+    @Schema(description = "리그 ID", example = "1")
+    private Long leagueId;
+
+    @Schema(description = "리그명", example = "프리미어리그")
+    private String leagueName;
+
+    /* 시즌 정보 */
+    @Schema(description = "리그 시즌 ID", example = "10")
+    private Long leagueSeasonId;
+
+    @Schema(description = "리그 시즌명", example = "2025/26")
+    private String leagueSeasonName;
+
+    @Schema(description = "리그 시즌 시작일", example = "2025-08-01")
+    private LocalDate leagueSeasonStartAt;
+
+    @Schema(description = "리그 시즌 종료일", example = "2026-05-31")
+    private LocalDate leagueSeasonEndAt;
+
+    @Schema(description = "현재 시즌 여부", example = "true")
+    private boolean isCurrentSeason;
+
+    public AdminLeagueSeasonResponse(
+            Long leagueId,
+            String leagueName,
+            Long leagueSeasonId,
+            String leagueSeasonName,
+            LocalDate leagueSeasonStartAt,
+            LocalDate leagueSeasonEndAt,
+            boolean isCurrentSeason) {
+
+        this.leagueId = leagueId;
+        this.leagueName = leagueName;
+        this.leagueSeasonId = leagueSeasonId;
+        this.leagueSeasonName = leagueSeasonName;
+        this.leagueSeasonStartAt = leagueSeasonStartAt;
+        this.leagueSeasonEndAt = leagueSeasonEndAt;
+        this.isCurrentSeason = isCurrentSeason;
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/dto/response/AdminLeagueSeasonStandingsResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/dto/response/AdminLeagueSeasonStandingsResponse.java
@@ -1,0 +1,59 @@
+package com.scorenow.scorenow_api.domain.league.dto.response;
+
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeason;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeasonStandings;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeasonStandingsType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(description = "관리자 리그 시즌 순위 관리 응답")
+@Getter
+@Builder
+public class AdminLeagueSeasonStandingsResponse {
+
+    /* 리그 정보 */
+    @Schema(description = "리그 ID", example = "1")
+    private Long leagueId;
+
+    @Schema(description = "리그명", example = "프리미어리그")
+    private String leagueName;
+
+    /* 시즌 정보 */
+    @Schema(description = "리그 시즌 ID", example = "10")
+    private Long leagueSeasonId;
+
+    @Schema(description = "시즌명", example = "2025/26")
+    private String seasonName;
+
+    @Schema(description = "현재 시즌 여부", example = "true")
+    private boolean isCurrentSeason;
+
+    /* 리그 시즌 순위 정보 (관리 타입, 이미지 등록 여부) */
+    @Schema(description = "리그 시즌 순위 관리 ID", example = "100")
+    private Long leagueSeasonStandingsId;
+
+    @Schema(description = "리그 시즌 순위 관리 타입", example = "EXTERNAL_DATA", allowableValues = {"IMAGE", "EXTERNAL_DATA"})
+    private LeagueSeasonStandingsType standingType;
+
+    @Schema(description = "순위 이미지 등록 여부. 이미지 타입 관리 시 사용합니다.", example = "false")
+    private Boolean standingImageRegistered;
+
+    public static AdminLeagueSeasonStandingsResponse from(LeagueSeasonStandings seasonStanding) {
+
+        LeagueSeason leagueSeason = seasonStanding.getLeagueSeason();
+        League league = leagueSeason.getLeague();
+
+        return AdminLeagueSeasonStandingsResponse.builder()
+                .leagueId(league.getId())
+                .leagueSeasonId(leagueSeason.getId())
+                .leagueSeasonStandingsId(seasonStanding.getId())
+                .leagueName(league.getKName() != null ? league.getKName() : league.getEName())
+                .seasonName(leagueSeason.getSeasonName())
+                .isCurrentSeason(leagueSeason.isCurrent())
+                .standingType(seasonStanding.getStandingsType())
+                .standingImageRegistered(seasonStanding.getImageUrl() != null && !seasonStanding.getImageUrl().isBlank())
+                .build();
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/entity/League.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/entity/League.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class  League extends BaseEntity {
+public class League extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeason.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeason.java
@@ -1,0 +1,124 @@
+package com.scorenow.scorenow_api.domain.league.entity;
+
+import com.scorenow.scorenow_api.global.entity.BaseEntity;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "league_seasons",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_league_seasons",
+                        columnNames = {"league_id", "season_name"}
+                )
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LeagueSeason extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "league_id", nullable = false)
+    private Long leagueId;
+
+    @Column(name = "season_name", nullable = false)
+    private String seasonName;
+
+    @Column(name = "season_start_at", nullable = false)
+    private LocalDate seasonStartAt;    // 관리자 페이지에서 한국 시간 기준으로 등록하기 때문에 KST 로 관리한다.
+
+    @Column(name = "season_end_at", nullable = false)
+    private LocalDate seasonEndAt;      // 관리자 페이지에서 한국 시간 기준으로 등록하기 때문에 KST 로 관리한다.
+
+    @Column(name = "is_current", nullable = false)
+    private boolean isCurrent;
+
+    // soft-delete (LeagueSeason 은 순위 뿐만 아니라 시즌 별 선수 스텟에도 관여할 수 있기 때문에 hard-delete 를 하지 않는다.)
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive = true;
+
+    // JPA 관계 추가 (Fetch join용)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "league_id", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private League league;
+
+    public static LeagueSeason create(
+            Long leagueId,
+            String seasonName,
+            LocalDate seasonStartAt,
+            LocalDate seasonEndAt,
+            boolean isCurrent
+    ) {
+        if (leagueId == null) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "리그 ID 는 필수입니다.");
+        }
+
+        validateSeasonName(seasonName);
+        validatePeriod(seasonStartAt, seasonEndAt);
+
+        LeagueSeason leagueSeason = new LeagueSeason();
+        leagueSeason.leagueId = leagueId;
+        leagueSeason.seasonName = seasonName;
+        leagueSeason.seasonStartAt = seasonStartAt;
+        leagueSeason.seasonEndAt = seasonEndAt;
+        leagueSeason.isCurrent = isCurrent;
+
+        return leagueSeason;
+    }
+
+    public void updateSeasonName(String seasonName) {
+        validateSeasonName(seasonName);
+
+        this.seasonName = seasonName;
+    }
+
+    public void updatePeriod(LocalDate seasonStartAt, LocalDate seasonEndAt) {
+        validatePeriod(seasonStartAt, seasonEndAt);
+
+        this.seasonStartAt = seasonStartAt;
+        this.seasonEndAt = seasonEndAt;
+    }
+
+    public void updateCurrent(boolean isCurrent) {
+        this.isCurrent = isCurrent;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+        this.isCurrent = false;
+    }
+
+    public boolean isSameId(Long leagueSeasonId) {
+        return this.id != null && this.id.equals(leagueSeasonId);
+    }
+
+    public boolean hasSameSeasonName(String seasonName) {
+        return this.seasonName.equals(seasonName);
+    }
+
+    public boolean overlapsWith(LocalDate startAt, LocalDate endAt) {
+        return !this.getSeasonStartAt().isAfter(endAt) && !this.getSeasonEndAt().isBefore(startAt);
+    }
+
+    private static void validateSeasonName(String seasonName) {
+        if (seasonName == null || seasonName.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "시즌명은 필수입니다.");
+        }
+    }
+
+    private static void validatePeriod(LocalDate seasonStartAt, LocalDate seasonEndAt) {
+        if (seasonStartAt == null || seasonEndAt == null) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "시즌 시작일과 종료일은 필수입니다.");
+        }
+
+        if (seasonStartAt.isAfter(seasonEndAt)) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "시즌 종료일이 시즌 시작일보다 과거일 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeasonStandings.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeasonStandings.java
@@ -1,0 +1,75 @@
+package com.scorenow.scorenow_api.domain.league.entity;
+
+import com.scorenow.scorenow_api.domain.common.enums.DataOrigin;
+import com.scorenow.scorenow_api.global.entity.BaseEntity;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "league_season_standings",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_league_season_standings_league_season_id",
+                        columnNames = "league_season_id"
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class LeagueSeasonStandings extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "league_season_id", nullable = false)
+    private Long leagueSeasonId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "standing_type", nullable = false)
+    private LeagueSeasonStandingsType standingsType;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    // JPA 관계 추가 (Fetch join용)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "league_season_id", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private LeagueSeason leagueSeason;
+
+    public static LeagueSeasonStandings from(LeagueSeason leagueSeason, LeagueSeasonStandingsType standingsType) {
+        if (leagueSeason == null) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "리그 시즌 정보는 필수입니다.");
+        }
+
+        if (standingsType == null) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "리그 순위 관리 타입은 필수입니다.");
+        }
+
+        League league = leagueSeason.getLeague();
+        if (league == null) {
+            throw new BusinessException(ErrorCode.LEAGUE_NOT_FOUND);
+        }
+
+        if (league.getDataOrigin() == DataOrigin.MANUAL && standingsType != LeagueSeasonStandingsType.IMAGE) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "수동 관리 리그는 이미지 타입만 선택할 수 있습니다.");
+        }
+
+        return LeagueSeasonStandings.builder()
+                .leagueSeasonId(leagueSeason.getId())
+                .standingsType(standingsType)
+                .build();
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "이미지 URL 은 필수입니다.");
+        }
+        this.imageUrl = imageUrl;
+    }
+
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeasonStandings.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeasonStandings.java
@@ -42,6 +42,18 @@ public class LeagueSeasonStandings extends BaseEntity {
     private LeagueSeason leagueSeason;
 
     public static LeagueSeasonStandings from(LeagueSeason leagueSeason, LeagueSeasonStandingsType standingsType) {
+        validateStandingsTypeAllowed(leagueSeason, standingsType);
+
+        return LeagueSeasonStandings.builder()
+                .leagueSeasonId(leagueSeason.getId())
+                .standingsType(standingsType)
+                .build();
+    }
+
+    public static void validateStandingsTypeAllowed(
+            LeagueSeason leagueSeason,
+            LeagueSeasonStandingsType standingsType
+    ) {
         if (leagueSeason == null) {
             throw new BusinessException(ErrorCode.INVALID_PARAMETER, "리그 시즌 정보는 필수입니다.");
         }
@@ -58,11 +70,6 @@ public class LeagueSeasonStandings extends BaseEntity {
         if (league.getDataOrigin() == DataOrigin.MANUAL && standingsType != LeagueSeasonStandingsType.IMAGE) {
             throw new BusinessException(ErrorCode.INVALID_PARAMETER, "수동 관리 리그는 이미지 타입만 선택할 수 있습니다.");
         }
-
-        return LeagueSeasonStandings.builder()
-                .leagueSeasonId(leagueSeason.getId())
-                .standingsType(standingsType)
-                .build();
     }
 
     public void updateImageUrl(String imageUrl) {
@@ -72,4 +79,12 @@ public class LeagueSeasonStandings extends BaseEntity {
         this.imageUrl = imageUrl;
     }
 
+    public void updateStandingsType(
+            LeagueSeason leagueSeason,
+            LeagueSeasonStandingsType newType
+    ) {
+        validateStandingsTypeAllowed(leagueSeason, newType);
+
+        this.standingsType = newType;
+    }
 }

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeasonStandingsType.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeasonStandingsType.java
@@ -1,0 +1,5 @@
+package com.scorenow.scorenow_api.domain.league.entity;
+
+public enum LeagueSeasonStandingsType {
+    IMAGE, EXTERNAL_DATA
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/mapper/LeagueSeasonStandingsMapper.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/mapper/LeagueSeasonStandingsMapper.java
@@ -3,15 +3,22 @@ package com.scorenow.scorenow_api.domain.league.mapper;
 import com.scorenow.scorenow_api.domain.league.document.LeagueSeasonStandingsDataDocument;
 import com.scorenow.scorenow_api.domain.league.dto.LeagueSeasonStandingsSyncTarget;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsStandingsResponse;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 
 @Component
 public class LeagueSeasonStandingsMapper {
     public LeagueSeasonStandingsDataDocument toDocument(
             BetsStandingsResponse.Result result,
             LeagueSeasonStandingsSyncTarget syncTarget) {
+
+        if (result == null) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "리그 순위 결과는 필수입니다.");
+        }
 
         BetsStandingsResponse.Season externalSeason = result.getSeason();
 
@@ -36,7 +43,14 @@ public class LeagueSeasonStandingsMapper {
             return null;
         }
 
-        BetsStandingsResponse.Table table = overall.getTables().get(0);
+        BetsStandingsResponse.Table table = overall.getTables().stream()
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+
+        if (table == null) {
+            return null;
+        }
 
         return LeagueSeasonStandingsDataDocument.StandingsTable.builder()
                 .name(table.getName())
@@ -53,6 +67,7 @@ public class LeagueSeasonStandingsMapper {
         }
 
         return rows.stream()
+                .filter(Objects::nonNull)
                 .map(this::toStandingRow)
                 .toList();
     }

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/mapper/LeagueSeasonStandingsMapper.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/mapper/LeagueSeasonStandingsMapper.java
@@ -1,0 +1,100 @@
+package com.scorenow.scorenow_api.domain.league.mapper;
+
+import com.scorenow.scorenow_api.domain.league.document.LeagueSeasonStandingsDataDocument;
+import com.scorenow.scorenow_api.domain.league.dto.LeagueSeasonStandingsSyncTarget;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsStandingsResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class LeagueSeasonStandingsMapper {
+    public LeagueSeasonStandingsDataDocument toDocument(
+            BetsStandingsResponse.Result result,
+            LeagueSeasonStandingsSyncTarget syncTarget) {
+
+        BetsStandingsResponse.Season externalSeason = result.getSeason();
+
+        return LeagueSeasonStandingsDataDocument.builder()
+                .leagueId(syncTarget.getLeagueId())
+                .apiLeagueId(syncTarget.getApiLeagueId())
+                .dataOrigin(syncTarget.getDataOrigin())
+                .leagueSeasonId(syncTarget.getLeagueSeasonId())
+                .externalSeasonName(externalSeason != null ? externalSeason.getName() : null)
+                .externalSeasonStartAt(externalSeason != null ? externalSeason.getStartTime() : null)
+                .externalSeasonEndAt(externalSeason != null ? externalSeason.getEndTime() : null)
+                .standingsTable(toStandingsTable(result.getOverall()))
+                .build();
+    }
+
+    private LeagueSeasonStandingsDataDocument.StandingsTable toStandingsTable(BetsStandingsResponse.Overall overall) {
+        if (overall == null) {
+            return null;
+        }
+
+        if (overall.getTables() == null || overall.getTables().isEmpty()) {
+            return null;
+        }
+
+        BetsStandingsResponse.Table table = overall.getTables().get(0);
+
+        return LeagueSeasonStandingsDataDocument.StandingsTable.builder()
+                .name(table.getName())
+                .groupName(table.getGroupName())
+                .currentRound(table.getCurrentRound())
+                .maxRounds(table.getMaxRounds())
+                .rows(toStandingsRows(table.getRows()))
+                .build();
+    }
+
+    private List<LeagueSeasonStandingsDataDocument.StandingsRow> toStandingsRows(List<BetsStandingsResponse.Row> rows) {
+        if (rows == null || rows.isEmpty()) {
+            return List.of();
+        }
+
+        return rows.stream()
+                .map(this::toStandingRow)
+                .toList();
+    }
+
+    private LeagueSeasonStandingsDataDocument.StandingsRow toStandingRow(BetsStandingsResponse.Row row) {
+        return LeagueSeasonStandingsDataDocument.StandingsRow.builder()
+                .position(row.getPos())
+                .positionChange(row.getChange())
+                .played(row.played())
+                .win(row.safeWin())
+                .draw(row.safeDraw())
+                .loss(row.safeLoss())
+                .goalsFor(row.safeGoalsFor())
+                .goalsAgainst(row.safeGoalsAgainst())
+                .goalDifference(row.goalDifference())
+                .points(row.getPoints())
+                .promotion(toPromotion(row.getPromotion()))
+                .team(toTeam(row.getTeam()))
+                .build();
+    }
+
+    private LeagueSeasonStandingsDataDocument.Promotion toPromotion(BetsStandingsResponse.Promotion promotion) {
+        if (promotion == null) {
+            return null;
+        }
+
+        return LeagueSeasonStandingsDataDocument.Promotion.builder()
+                .name(promotion.getName())
+                .shortName(promotion.getShortName())
+                .build();
+    }
+
+    private LeagueSeasonStandingsDataDocument.Team toTeam(BetsStandingsResponse.Team team) {
+        if (team == null) {
+            return null;
+        }
+
+        return LeagueSeasonStandingsDataDocument.Team.builder()
+                .apiTeamId(team.getId())
+                .name(team.getName())
+                .imageId(team.getImageId())
+                .countryCode(team.getCc())
+                .build();
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/repository/LeagueSeasonRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/repository/LeagueSeasonRepository.java
@@ -1,0 +1,67 @@
+package com.scorenow.scorenow_api.domain.league.repository;
+
+import com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonResponse;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeason;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LeagueSeasonRepository extends JpaRepository<LeagueSeason, Long> {
+    boolean existsByLeagueIdAndSeasonName(Long leagueId, String seasonName);
+
+    @Query(value = """
+            select ls
+            from LeagueSeason ls
+            where ls.isCurrent = true
+              and ls.leagueId = :leagueId
+              and ls.isActive = true
+            """)
+    Optional<LeagueSeason> findCurrentSeasonByLeagueId(@Param("leagueId") Long leagueId);
+
+    Optional<LeagueSeason> findByIdAndIsActiveTrue(Long id);
+
+    List<LeagueSeason> findAllByLeagueIdAndIsActiveTrue(Long leagueId);
+
+    @Query(value = """
+            select new com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonResponse(
+                ls.id,
+                coalesce(l.kName, l.eName),
+                ls.id,
+                ls.seasonName,
+                ls.seasonStartAt,
+                ls.seasonEndAt,
+                ls.isCurrent
+            )
+            from LeagueSeason ls
+            join ls.league l
+            where (:leagueId is null or ls.leagueId = :leagueId)
+              and (
+                    :leagueName is null
+                    or l.kName like concat('%',:leagueName,'%')
+                    or lower(l.eName) like lower(concat('%',:leagueName,'%'))
+              )
+              and ls.isActive = true
+            order by ls.isCurrent desc, ls.seasonStartAt desc
+            """,
+           countQuery = """
+            select count(ls)
+            from LeagueSeason ls
+            join ls.league l
+            where (:leagueId is null or ls.leagueId = :leagueId)
+              and (
+                    :leagueName is null
+                    or l.kName like concat('%',:leagueName,'%')
+                    or lower(l.eName) like lower(concat('%',:leagueName,'%'))
+              )
+              and ls.isActive = true
+            """)
+    Page<AdminLeagueSeasonResponse> searchLeagueSeasons(
+            @Param("leagueId") Long leagueId,
+            @Param("leagueName") String leagueName,
+            Pageable pageable);
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/repository/LeagueSeasonRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/repository/LeagueSeasonRepository.java
@@ -21,7 +21,7 @@ public interface LeagueSeasonRepository extends JpaRepository<LeagueSeason, Long
               and ls.leagueId = :leagueId
               and ls.isActive = true
             """)
-    Optional<LeagueSeason> findCurrentSeasonByLeagueId(@Param("leagueId") Long leagueId);
+    List<LeagueSeason> findCurrentSeasonByLeagueId(@Param("leagueId") Long leagueId);
 
     Optional<LeagueSeason> findByIdAndIsActiveTrue(Long id);
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/repository/LeagueSeasonStandingsMongoRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/repository/LeagueSeasonStandingsMongoRepository.java
@@ -1,0 +1,8 @@
+package com.scorenow.scorenow_api.domain.league.repository;
+
+import com.scorenow.scorenow_api.domain.league.document.LeagueSeasonStandingsDataDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface LeagueSeasonStandingsMongoRepository extends MongoRepository<LeagueSeasonStandingsDataDocument, String> {
+    void deleteByLeagueSeasonId(Long leagueSeasonId);
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/repository/LeagueSeasonStandingsRepository.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/repository/LeagueSeasonStandingsRepository.java
@@ -1,0 +1,72 @@
+package com.scorenow.scorenow_api.domain.league.repository;
+
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeasonStandings;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeasonStandingsType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LeagueSeasonStandingsRepository extends JpaRepository<LeagueSeasonStandings, Long> {
+    boolean existsByLeagueSeasonId(Long leagueSeasonId);
+
+    Optional<LeagueSeasonStandings> findByLeagueSeasonId(Long leagueSeasonId);
+
+    @Query(value = """
+            select lss
+            from LeagueSeasonStandings lss
+            join fetch lss.leagueSeason ls
+            join fetch ls.league l
+            where lss.leagueSeasonId = :leagueSeasonId
+              and ls.isActive = true
+            """)
+    Optional<LeagueSeasonStandings> findByLeagueSeasonIdWithSeasonAndLeague(
+            @Param("leagueSeasonId") Long leagueSeasonId);
+
+    @Query(value = """
+            select lss
+            from LeagueSeasonStandings lss
+            join fetch lss.leagueSeason ls
+            join fetch ls.league l
+            where (:leagueId is null or :leagueId = l.id)
+              and (
+                   :leagueName is null
+                   or l.kName like concat('%', :leagueName, '%')
+                   or lower(l.eName) like lower(concat('%', :leagueName, '%'))
+              )
+              and ls.isActive = true
+            """,
+            countQuery = """
+            select count(s)
+            from LeagueSeasonStandings s
+            join s.leagueSeason ls
+            join ls.league l
+            where (:leagueId is null or l.id = :leagueId)
+              and (
+                   :leagueName is null
+                   or l.kName like concat('%', :leagueName, '%')
+                   or lower(l.eName) like lower(concat('%', :leagueName, '%'))
+              )
+              and ls.isActive = true
+            """
+    )
+    Page<LeagueSeasonStandings> searchLeagueSeasonStandings(
+            @Param("leagueId") Long leagueId,
+            @Param("leagueName") String leagueName,
+            Pageable pageable);
+
+    @Query(value = """
+            select lss.leagueSeasonId
+            from LeagueSeasonStandings lss
+            join lss.leagueSeason ls
+            where ls.isCurrent = true
+              and ls.isActive = true
+              and lss.standingsType = :standingsType
+            """)
+    List<Long> findCurrentLeagueSeasonIdsByStandingType(
+            @Param("standingsType") LeagueSeasonStandingsType standingsType);
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/scheduler/LeagueSeasonStandingsSyncScheduler.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/scheduler/LeagueSeasonStandingsSyncScheduler.java
@@ -1,0 +1,44 @@
+package com.scorenow.scorenow_api.domain.league.scheduler;
+
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeasonStandingsType;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueSeasonStandingsRepository;
+import com.scorenow.scorenow_api.domain.league.service.LeagueSeasonStandingsSyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LeagueSeasonStandingsSyncScheduler {
+
+    private final LeagueSeasonStandingsRepository leagueSeasonStandingsRepository;
+    private final LeagueSeasonStandingsSyncService leagueSeasonStandingsSyncService;
+
+    /**
+     * 리그 순위 데이터 동기화 (외부 API)
+     * 작업 주기: 08:30 / 20:30 (매일 2회, KST)
+     */
+    @Scheduled(cron = "0 30 8,20 * * *", zone = "Asia/Seoul")
+    public void syncExternalStandingsData() {
+        // 동기화 대상 조회
+        List<Long> leagueSeasonIds = leagueSeasonStandingsRepository
+                .findCurrentLeagueSeasonIdsByStandingType(LeagueSeasonStandingsType.EXTERNAL_DATA);
+
+        log.info("📅리그 시즌 순위 동기화 시작 - 대상 {}건", leagueSeasonIds.size());
+
+        // 동기화
+        for (Long leagueSeasonId : leagueSeasonIds) {
+            try {
+                leagueSeasonStandingsSyncService.sync(leagueSeasonId);
+            } catch (Exception e) {
+                log.error("리그 시즌 순위 동기화 실패 - leagueSeasonId={}", leagueSeasonId, e);
+            }
+        }
+
+        log.info("📅리그 시즌 순위 동기화 종료");
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonService.java
@@ -66,7 +66,7 @@ public class AdminLeagueSeasonService {
         // 새로운 "현재 시즌" 등록의 경우 기존 "현재 시즌" 을 해제
         if (request.isCurrent()) {
             leagueSeasonRepository.findCurrentSeasonByLeagueId(leagueId)
-                    .ifPresent(leagueSeason -> leagueSeason.updateCurrent(false));
+                    .forEach(leagueSeason -> leagueSeason.updateCurrent(false));
         }
 
         // 등록

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonService.java
@@ -1,0 +1,193 @@
+package com.scorenow.scorenow_api.domain.league.service;
+
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonCreateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonSearchCondition;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonUpdateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonResponse;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeason;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueRepository;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueSeasonRepository;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminLeagueSeasonService {
+
+    private final LeagueSeasonRepository leagueSeasonRepository;
+    private final LeagueRepository leagueRepository;
+
+    /**
+     * 리그 시즌 생성
+     */
+    @Transactional
+    public void createLeagueSeason(LeagueSeasonCreateRequest request) {
+
+        Long leagueId = request.getLeagueId();
+        String seasonName = normalize(request.getSeasonName());
+
+        // 리그 존재 여부 검증
+        if (!leagueRepository.existsById(leagueId)) {
+            throw new BusinessException(ErrorCode.LEAGUE_NOT_FOUND);
+        }
+
+        // 리그 ID + 시즌명으로 기등록 데이터 검증
+        if (leagueSeasonRepository.existsByLeagueIdAndSeasonName(leagueId, seasonName)) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "이미 해당 리그에 등록된 시즌명입니다.");
+        }
+
+        // 시즌 일정 유효성 검증 (startAt <= endAt)
+        LocalDate seasonStartAt = request.getSeasonStartAt();
+        LocalDate seasonEndAt = request.getSeasonEndAt();
+        if (seasonStartAt.isAfter(seasonEndAt)) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "시즌 종료일이 시즌 시작일보다 과거일 수 없습니다.");
+        }
+
+        // 리그와 연계된 시즌들중 현재 등록하고자 하는 시즌 정보와 일정이 겹치는 시즌이 있는지 확인
+        List<LeagueSeason> leagueSeasons = leagueSeasonRepository.findAllByLeagueIdAndIsActiveTrue(leagueId);
+        for (LeagueSeason leagueSeason : leagueSeasons) {
+            if (leagueSeason.overlapsWith(seasonStartAt, seasonEndAt)) {
+                throw new BusinessException(ErrorCode.INVALID_PARAMETER, "시즌 일정이 겹치는 시즌이 존재합니다.");
+            }
+        }
+
+        // 새로운 "현재 시즌" 등록의 경우 기존 "현재 시즌" 을 해제
+        if (request.isCurrent()) {
+            leagueSeasonRepository.findCurrentSeasonByLeagueId(leagueId)
+                    .ifPresent(leagueSeason -> leagueSeason.updateCurrent(false));
+        }
+
+        // 등록
+        LeagueSeason leagueSeason = LeagueSeason.create(
+                leagueId,
+                seasonName,
+                request.getSeasonStartAt(), request.getSeasonEndAt(),
+                request.isCurrent());
+
+        leagueSeasonRepository.save(leagueSeason);
+    }
+
+    /**
+     * 리그 시즌 검색
+     * 조회 조건 : 전체 조회, 리그 ID, 리그 명
+     * 정렬 순서 : 현재 시즌 -> 시즌 시작일 최근순)
+     */
+    public Page<AdminLeagueSeasonResponse> searchLeagueSeasons(
+            LeagueSeasonSearchCondition condition,
+            Pageable pageable) {
+
+        LeagueSeasonSearchCondition safeCondition = condition != null
+                ? condition
+                : new LeagueSeasonSearchCondition();
+
+        return leagueSeasonRepository.searchLeagueSeasons(
+                safeCondition.getLeagueId(),
+                normalize(safeCondition.getLeagueName()),
+                pageable);
+    }
+
+    /**
+     * 리그 시즌 수정
+     */
+    @Transactional
+    public void updateLeagueSeason(Long leagueSeasonId, LeagueSeasonUpdateRequest request) {
+        if (request == null) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "수정 요청 정보는 필수입니다.");
+        }
+
+        // 시즌 존재 여부 확인
+        LeagueSeason target = leagueSeasonRepository.findByIdAndIsActiveTrue(leagueSeasonId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "시즌 정보를 찾을 수 없습니다."));
+
+        // 리그의 모든 시즌을 조회 (시즌명 중복 및 일정 중복 검증 용도)
+        List<LeagueSeason> seasons = leagueSeasonRepository.findAllByLeagueIdAndIsActiveTrue(target.getLeagueId());
+
+        // 시즌명 변경 시, 시즌명 중복 여부 확인 (같은 리그 한해서만)
+        String newSeasonName = normalize(request.getSeasonName()) != null
+                ? normalize(request.getSeasonName())
+                : target.getSeasonName();
+
+        validateDuplicateSeasonName(seasons, target, newSeasonName);
+        target.updateSeasonName(newSeasonName);
+
+        // 시즌 시작일, 종료일 변경 시, 시즌 일정 유효성 검증 (startAt<=endAt / 일정 겹치는지 / 단, 대상 시즌(target) 제외)
+        LocalDate newSeasonStartAt = request.getSeasonStartAt() != null
+                ? request.getSeasonStartAt()
+                : target.getSeasonStartAt();
+
+        LocalDate newSeasonEndAt = request.getSeasonEndAt() != null
+                ? request.getSeasonEndAt()
+                : target.getSeasonEndAt();
+
+        validateOverlappingPeriod(seasons, target, newSeasonStartAt, newSeasonEndAt);
+        target.updatePeriod(newSeasonStartAt, newSeasonEndAt);
+
+        // 현재 시즌 설정 시, 기존 다른 현재 시즌 설정 해제
+        if (request.getIsCurrent() != null) {
+            if (Boolean.TRUE.equals(request.getIsCurrent())) {
+                seasons.stream()
+                        .filter(season -> !season.isSameId(target.getId())) // Target 은 제외
+                        .filter(LeagueSeason::isCurrent)    // '현재 시즌' 인 시즌을 필터링
+                        .forEach(season -> season.updateCurrent(false));    // '현재 시즌' false 로 변경
+            }
+
+            target.updateCurrent(request.getIsCurrent());
+        }
+    }
+
+    /**
+     * 리그 시즌 삭제
+     */
+    @Transactional
+    public void deleteLeagueSeason(Long leagueSeasonId) {
+        LeagueSeason leagueSeason = leagueSeasonRepository.findByIdAndIsActiveTrue(leagueSeasonId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "시즌 정보를 찾을 수 없습니다."));
+
+        leagueSeason.deactivate();
+    }
+
+    private void validateOverlappingPeriod(
+            List<LeagueSeason> seasons,
+            LeagueSeason target,
+            LocalDate newSeasonStartAt,
+            LocalDate newSeasonEndAt) {
+
+        boolean overlapped = seasons.stream()
+                .filter(season -> !season.isSameId(target.getId()))
+                .anyMatch(season -> season.overlapsWith(newSeasonStartAt, newSeasonEndAt));
+
+        if (overlapped) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "시즌 일정이 겹치는 시즌이 존재합니다.");
+        }
+    }
+
+    private void validateDuplicateSeasonName(
+            List<LeagueSeason> seasons,
+            LeagueSeason target,
+            String newSeasonName) {
+
+        boolean isSeasonNameDuplicated = seasons.stream()
+                .filter(season -> !season.isSameId(target.getId()))
+                .anyMatch(season -> season.hasSameSeasonName(newSeasonName));
+
+        if (isSeasonNameDuplicated) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "이미 해당 리그에 등록된 시즌명입니다.");
+        }
+    }
+
+    private String normalize(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonStandingsService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonStandingsService.java
@@ -1,0 +1,156 @@
+package com.scorenow.scorenow_api.domain.league.service;
+
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsCreateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsSearchCondition;
+import com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonStandingsResponse;
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeason;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeasonStandings;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeasonStandingsType;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueExternalMappingRepository;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueSeasonRepository;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueSeasonStandingsMongoRepository;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueSeasonStandingsRepository;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import com.scorenow.scorenow_api.global.infra.storage.FileStorage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminLeagueSeasonStandingsService {
+
+    private final LeagueSeasonRepository leagueSeasonRepository;
+    private final LeagueExternalMappingRepository leagueExternalMappingRepository;
+    private final LeagueSeasonStandingsRepository leagueSeasonStandingsRepository;
+    private final LeagueSeasonStandingsMongoRepository leagueSeasonStandingsMongoRepository;
+
+    private final LeagueSeasonStandingsSyncService leagueSeasonStandingsSyncService;
+
+    private final FileStorage fileStorage;
+
+    /**
+     * 리그 순위 관리 방식 등록
+     * - League 의 DataOrigin 이 MANUAL 이면, LeagueStandingType 은 IMAGE 만 허용
+     * - LeagueStandingType 이 EXTERNAL_DATA 이면, LeagueExternalMapping 이 있어야 함
+     */
+    @Transactional
+    public void createLeagueSeasonStandings(LeagueSeasonStandingsCreateRequest createRequest) {
+        Long leagueSeasonId = createRequest.getLeagueSeasonId();
+        LeagueSeasonStandingsType standingsType = createRequest.getStandingsType();
+
+        LeagueSeason leagueSeason = leagueSeasonRepository.findByIdAndIsActiveTrue(leagueSeasonId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_PARAMETER, "존재하지 않는 시즌입니다."));
+
+        // 이미 관리되는 LeagueSeason 인지 확인
+        if (leagueSeasonStandingsRepository.existsByLeagueSeasonId(leagueSeasonId)) {
+            throw new BusinessException(ErrorCode.LEAGUE_ALREADY_EXISTS, "이미 순위 관리 중인 시즌입니다.");
+        }
+
+        // 순위 정보를 외부 데이터에 기반하는 경우, 사전에 리그 외부 매핑 정보가 있는지 확인
+        if (standingsType == LeagueSeasonStandingsType.EXTERNAL_DATA) {
+            League league = leagueSeason.getLeague();
+
+            leagueExternalMappingRepository.findByDataOriginAndInternalLeagueId(league.getDataOrigin(), league.getId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_PARAMETER, "외부 API 리그 매핑이 필요합니다."));
+        }
+
+        // 등록
+        leagueSeasonStandingsRepository.save(LeagueSeasonStandings.from(leagueSeason, standingsType));
+    }
+
+    /**
+     * 리그 시즌 순위 검색 (전체 조회, 리그명, 리그ID)
+     */
+    public Page<AdminLeagueSeasonStandingsResponse> searchLeagueSeasonStandings(
+            LeagueSeasonStandingsSearchCondition condition,
+            Pageable pageable) {
+
+        LeagueSeasonStandingsSearchCondition safeCondition = condition != null
+                ? condition
+                : new LeagueSeasonStandingsSearchCondition();
+
+        // 리그 시즌 순위 조회
+        Page<LeagueSeasonStandings> seasonStandings = leagueSeasonStandingsRepository.searchLeagueSeasonStandings(
+                safeCondition.getLeagueId(),
+                normalize(safeCondition.getLeagueName()),
+                pageable
+        );
+
+        return seasonStandings.map(AdminLeagueSeasonStandingsResponse::from);
+    }
+
+    /**
+     * 리그 순위 관리 방식 삭제
+     */
+    @Transactional
+    public void deleteLeagueSeasonStandings(Long leagueSeasonId) {
+
+        // LeagueSeasonStanding 조회
+        LeagueSeasonStandings seasonStanding = leagueSeasonStandingsRepository
+                .findByLeagueSeasonId(leagueSeasonId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "리그 시즌 순위 정보를 찾을 수 없습니다."));
+
+        if (seasonStanding.getStandingsType() == LeagueSeasonStandingsType.EXTERNAL_DATA) {
+            leagueSeasonStandingsMongoRepository.deleteByLeagueSeasonId(leagueSeasonId);
+        }
+
+        leagueSeasonStandingsRepository.delete(seasonStanding);
+    }
+
+    /**
+     * 리그 시즌 순위 이미지 등록 (관리 타입이 IMAGE 인 경우에만 가능)
+     */
+    @Transactional
+    public void uploadLeagueSeasonStandingsImage(
+            Long leagueSeasonId,
+            MultipartFile image) {
+
+        // LeagueSeasonStanding 조회
+        LeagueSeasonStandings seasonStanding = leagueSeasonStandingsRepository
+                .findByLeagueSeasonId(leagueSeasonId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "리그 시즌 순위 정보를 찾을 수 없습니다."));
+
+        // 리그 순위가 이미지 타입으로 관리되지 않는 경우 업로드에 실패
+        if (seasonStanding.getStandingsType() != LeagueSeasonStandingsType.IMAGE) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "이미지 타입으로 관리 중인 리그만 이미지를 등록할 수 있습니다.");
+        }
+
+        // 리그 순위 이미지 업로드
+        String imageUrl = fileStorage.uploadFile(image);
+
+        // 리그 순위 이미지 등록 또는 갱신
+        seasonStanding.updateImageUrl(imageUrl);
+    }
+
+    /**
+     * 리그 시즌 순위 데이터 동기화 (관리 타입이 DATA 인 경우에만 가능)
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void syncLeagueSeasonStandingsData(Long leagueSeasonId) {
+        LeagueSeasonStandings seasonStanding = leagueSeasonStandingsRepository
+                .findByLeagueSeasonId(leagueSeasonId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "리그 시즌 순위 정보를 찾을 수 없습니다."));
+
+        if (seasonStanding.getStandingsType() != LeagueSeasonStandingsType.EXTERNAL_DATA) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "외부 데이터 타입으로 관리 중인 리그만 동기화할 수 있습니다.");
+        }
+
+        leagueSeasonStandingsSyncService.sync(leagueSeasonId);
+    }
+
+
+    private String normalize(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonStandingsService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonStandingsService.java
@@ -2,6 +2,7 @@ package com.scorenow.scorenow_api.domain.league.service;
 
 import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsCreateRequest;
 import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsSearchCondition;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsTypeUpdateRequest;
 import com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonStandingsResponse;
 import com.scorenow.scorenow_api.domain.league.entity.League;
 import com.scorenow.scorenow_api.domain.league.entity.LeagueSeason;
@@ -57,6 +58,8 @@ public class AdminLeagueSeasonStandingsService {
             throw new BusinessException(ErrorCode.LEAGUE_ALREADY_EXISTS, "이미 순위 관리 중인 시즌입니다.");
         }
 
+        LeagueSeasonStandings.validateStandingsTypeAllowed(leagueSeason, standingsType);
+
         // 순위 정보를 외부 데이터에 기반하는 경우, 사전에 리그 외부 매핑 정보가 있는지 확인
         if (standingsType == LeagueSeasonStandingsType.EXTERNAL_DATA) {
             League league = leagueSeason.getLeague();
@@ -91,6 +94,36 @@ public class AdminLeagueSeasonStandingsService {
     }
 
     /**
+     * 리그 순위 관리 방식 타입 변경
+     */
+    @Transactional
+    public void updateLeagueSeasonStandingsType(Long leagueSeasonId, LeagueSeasonStandingsTypeUpdateRequest updateRequest) {
+
+        LeagueSeasonStandingsType newType = updateRequest.getStandingsType();
+
+        LeagueSeasonStandings seasonStanding = leagueSeasonStandingsRepository
+                .findByLeagueSeasonIdWithSeasonAndLeague(leagueSeasonId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "리그 시즌 순위 정보를 찾을 수 없습니다."));
+
+        // 변화가 없는 경우 종료
+        if (seasonStanding.getStandingsType() == newType) {
+            return;
+        }
+
+        LeagueSeason leagueSeason = seasonStanding.getLeagueSeason();
+        LeagueSeasonStandings.validateStandingsTypeAllowed(leagueSeason, newType);
+        League league = leagueSeason.getLeague();
+
+        // 외부 데이터를 사용하게끔 변경한다면, League External Mapping 에 사전 등록되어 있어야 한다.
+        if (newType == LeagueSeasonStandingsType.EXTERNAL_DATA) {
+            leagueExternalMappingRepository.findByDataOriginAndInternalLeagueId(league.getDataOrigin(), league.getId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_PARAMETER, "외부 API 리그 매핑이 필요합니다."));
+        }
+
+        seasonStanding.updateStandingsType(leagueSeason, newType);
+    }
+
+    /**
      * 리그 순위 관리 방식 삭제
      */
     @Transactional
@@ -101,10 +134,7 @@ public class AdminLeagueSeasonStandingsService {
                 .findByLeagueSeasonId(leagueSeasonId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "리그 시즌 순위 정보를 찾을 수 없습니다."));
 
-        if (seasonStanding.getStandingsType() == LeagueSeasonStandingsType.EXTERNAL_DATA) {
-            leagueSeasonStandingsMongoRepository.deleteByLeagueSeasonId(leagueSeasonId);
-        }
-
+        leagueSeasonStandingsMongoRepository.deleteByLeagueSeasonId(leagueSeasonId);
         leagueSeasonStandingsRepository.delete(seasonStanding);
     }
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncService.java
@@ -1,0 +1,67 @@
+package com.scorenow.scorenow_api.domain.league.service;
+
+import com.scorenow.scorenow_api.domain.league.document.LeagueSeasonStandingsDataDocument;
+import com.scorenow.scorenow_api.domain.league.dto.LeagueSeasonStandingsSyncTarget;
+import com.scorenow.scorenow_api.domain.league.entity.*;
+import com.scorenow.scorenow_api.domain.league.mapper.LeagueSeasonStandingsMapper;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueExternalMappingRepository;
+import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsStandingsResponse;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LeagueSeasonStandingsSyncService {
+
+    private final LeagueSeasonStandingsSyncTargetReader syncTargetReader;
+    private final BetsApiClient betsApiClient;
+    private final MongoTemplate mongoTemplate;
+
+    private final LeagueSeasonStandingsMapper mapper;
+
+    /**
+     * 리그 시즌 순위 동기화
+     */
+    public void sync(Long leagueSeasonId) {
+
+        // 동기화 대상 관련 정보 조회
+        LeagueSeasonStandingsSyncTarget syncTarget = syncTargetReader.read(leagueSeasonId);
+
+        // 리그 순위 API 호출
+        BetsStandingsResponse response = betsApiClient.getStandings(syncTarget.getApiLeagueId());
+
+        if (response == null || !response.isSuccess()) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "리그 순위 API 호출에 실패했습니다.");
+        }
+
+        if (!response.hasResults()) {
+            log.info("🟠리그 순위 데이터가 없습니다.");
+            return;
+        }
+
+        LeagueSeasonStandingsDataDocument document = mapper.toDocument(response.getResults().get(0), syncTarget);
+
+        Query query = new Query(Criteria.where("leagueSeasonId").is(document.getLeagueSeasonId()));
+
+        Update update = new Update();
+        update.set("leagueId", document.getLeagueId());
+        update.set("apiLeagueId", document.getApiLeagueId());
+        update.set("dataOrigin", document.getDataOrigin());
+        update.set("leagueSeasonId", document.getLeagueSeasonId());
+        update.set("externalSeasonName", document.getExternalSeasonName());
+        update.set("externalSeasonStartAt", document.getExternalSeasonStartAt());
+        update.set("externalSeasonEndAt", document.getExternalSeasonEndAt());
+        update.set("standingsTable", document.getStandingsTable());
+
+        mongoTemplate.upsert(query, update, LeagueSeasonStandingsDataDocument.class);
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncService.java
@@ -2,9 +2,7 @@ package com.scorenow.scorenow_api.domain.league.service;
 
 import com.scorenow.scorenow_api.domain.league.document.LeagueSeasonStandingsDataDocument;
 import com.scorenow.scorenow_api.domain.league.dto.LeagueSeasonStandingsSyncTarget;
-import com.scorenow.scorenow_api.domain.league.entity.*;
 import com.scorenow.scorenow_api.domain.league.mapper.LeagueSeasonStandingsMapper;
-import com.scorenow.scorenow_api.domain.league.repository.LeagueExternalMappingRepository;
 import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsStandingsResponse;
 import com.scorenow.scorenow_api.global.exception.BusinessException;

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncService.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncService.java
@@ -46,7 +46,10 @@ public class LeagueSeasonStandingsSyncService {
             return;
         }
 
-        LeagueSeasonStandingsDataDocument document = mapper.toDocument(response.getResults().get(0), syncTarget);
+        BetsStandingsResponse.Result result = response.firstResult()
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_PARAMETER, "리그 순위 API 응답에 유효한 결과가 없습니다."));
+
+        LeagueSeasonStandingsDataDocument document = mapper.toDocument(result, syncTarget);
 
         Query query = new Query(Criteria.where("leagueSeasonId").is(document.getLeagueSeasonId()));
 

--- a/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncTargetReader.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncTargetReader.java
@@ -1,0 +1,50 @@
+package com.scorenow.scorenow_api.domain.league.service;
+
+import com.scorenow.scorenow_api.domain.league.dto.LeagueSeasonStandingsSyncTarget;
+import com.scorenow.scorenow_api.domain.league.entity.*;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueExternalMappingRepository;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueSeasonStandingsRepository;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LeagueSeasonStandingsSyncTargetReader {
+
+    private final LeagueSeasonStandingsRepository leagueSeasonStandingsRepository;
+    private final LeagueExternalMappingRepository leagueExternalMappingRepository;
+
+    public LeagueSeasonStandingsSyncTarget read(Long leagueSeasonId) {
+        // LeagueSeasonStanding 조회
+        LeagueSeasonStandings seasonStanding = leagueSeasonStandingsRepository
+                .findByLeagueSeasonIdWithSeasonAndLeague(leagueSeasonId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "리그 시즌 순위 정보를 찾을 수 없습니다."));
+
+        // 리그 순위가 EXTERNAL_DATA 타입으로 관리되지 않는 경우 업로드에 실패
+        if (seasonStanding.getStandingsType() != LeagueSeasonStandingsType.EXTERNAL_DATA) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "데이터 타입으로 관리 중인 리그만 동기화 할 수 있습니다.");
+        }
+
+        LeagueSeason leagueSeason = seasonStanding.getLeagueSeason();
+        League league = leagueSeason.getLeague();
+
+        // 외부 API 리그 ID 조회
+        LeagueExternalMapping leagueExternalMapping = leagueExternalMappingRepository
+                .findByDataOriginAndInternalLeagueId(league.getDataOrigin(), league.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.LEAGUE_NOT_FOUND, "외부 API 리그 ID 가 존재하지 않습니다."));
+
+        return LeagueSeasonStandingsSyncTarget.builder()
+                .leagueId(league.getId())
+                .leagueSeasonId(leagueSeasonId)
+                .leagueSeasonStandingsId(seasonStanding.getId())
+                .apiLeagueId(leagueExternalMapping.getApiLeagueId())
+                .dataOrigin(leagueExternalMapping.getDataOrigin())
+                .build();
+    }
+}

--- a/src/main/java/com/scorenow/scorenow_api/domain/match/document/MatchCommentaryDocument.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/document/MatchCommentaryDocument.java
@@ -1,13 +1,15 @@
 package com.scorenow.scorenow_api.domain.match.document;
 
 import com.scorenow.scorenow_api.global.entity.BaseDocument;
-import jakarta.persistence.Id;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Getter @Builder
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Document(collection = "match_commentaries")
 public class MatchCommentaryDocument extends BaseDocument {
     @Id

--- a/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsStandingsResponse.java
+++ b/src/main/java/com/scorenow/scorenow_api/external/betsapi/dto/BetsStandingsResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.scorenow.scorenow_api.domain.common.enums.DataOrigin;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,44 +12,137 @@ import lombok.Setter;
 @Getter
 @Setter
 public class BetsStandingsResponse {
+    private final DataOrigin provider = DataOrigin.BETS;
 
-	private Integer success;
-	private List<Result> results;
+    private Integer success;
+    private List<Result> results;
 
-	@Getter
-	@Setter
-	public static class Result {
-		private Overall overall;
-	}
+    public boolean isSuccess() {
+        return Integer.valueOf(1).equals(success);
+    }
 
-	@Getter
-	@Setter
-	public static class Overall {
-		private List<Table> tables;
-	}
+    public boolean hasResults() {
+        return isSuccess() && results != null && !results.isEmpty();
+    }
 
-	@Getter
-	@Setter
-	public static class Table {
-		private List<Row> rows;
-	}
+    @Getter
+    @Setter
+    public static class Result {
+        private Season season;
+        private Overall overall;
+    }
 
-	@Getter
-	@Setter
-	public static class Row {
-		private Team team;
-	}
+    @Getter
+    @Setter
+    public static class Season {
+        @JsonProperty("sport_id")
+        private Integer sportId;
 
-	@Getter
-	@Setter
-	@EqualsAndHashCode(of = "id")
-	public static class Team {
-		private String id;
-		private String name;
+        @JsonProperty("start_time")
+        private Long startTime;
 
-		@JsonProperty("image_id")
-		private String imageId;
+        @JsonProperty("end_time")
+        private Long endTime;
 
-		private String cc;
-	}
+        private String name;
+    }
+
+    @Getter
+    @Setter
+    public static class Overall {
+        private List<Table> tables;
+    }
+
+    @Getter
+    @Setter
+    public static class Table {
+        @JsonProperty("name")
+        private String name;
+
+        @JsonProperty("groupname")
+        private String groupName;
+
+        @JsonProperty("currentround")
+        private Integer currentRound;
+
+        @JsonProperty("maxrounds")
+        private Integer maxRounds;
+
+        private List<Row> rows;
+    }
+
+    @Getter
+    @Setter
+    public static class Row {
+        private Integer pos;            // 순위
+        private Integer change;         // 순위 변동값 (ex: 1위→2위 = -1 / 3위→1위 = 2)
+        private Integer win;            // 승
+        private Integer draw;           // 무
+        private Integer loss;           // 패
+
+        @JsonProperty("goalsfor")
+        private Integer goalsFor;       // 득점
+
+        @JsonProperty("goalsagainst")
+        private Integer goalsAgainst;   // 실점
+
+        private Integer points;         // 승점
+        private Promotion promotion;    // 승격,진출,강등 상태
+
+        private Team team;              // 팀 정보
+
+        public int played() {
+            return valueOrZero(win) + valueOrZero(draw) + valueOrZero(loss);
+        }
+
+        public int goalDifference() {
+            return valueOrZero(goalsFor) - valueOrZero(goalsAgainst);
+        }
+
+        public int safeWin() {
+            return valueOrZero(win);
+        }
+
+        public int safeDraw() {
+            return valueOrZero(draw);
+        }
+
+        public int safeLoss() {
+            return valueOrZero(loss);
+        }
+
+        public int safeGoalsFor() {
+            return valueOrZero(goalsFor);
+        }
+
+        public int safeGoalsAgainst() {
+            return valueOrZero(goalsAgainst);
+        }
+
+        private int valueOrZero(Integer value) {
+            return value != null ? value : 0;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class Promotion {
+        private String name;            // ex: Champions League, Europa League, Relegation
+
+        @JsonProperty("shortname")
+        private String shortName;       // ex: CL, UEFA, rel
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(of = "id")
+    public static class Team {
+        private String id;
+        private String name;
+
+        @JsonProperty("image_id")
+        private String imageId;
+
+        private String cc;
+    }
 }

--- a/src/test/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeasonStandingsTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeasonStandingsTest.java
@@ -1,0 +1,118 @@
+package com.scorenow.scorenow_api.domain.league.entity;
+
+import com.scorenow.scorenow_api.domain.common.enums.DataOrigin;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LeagueSeasonStandingsTest {
+
+    @Test
+    void 수동_관리_리그는_이미지_타입으로_순위_관리를_생성한다() {
+        LeagueSeason leagueSeason = season(manualLeague(1L));
+
+        LeagueSeasonStandings standings = LeagueSeasonStandings.from(
+                leagueSeason,
+                LeagueSeasonStandingsType.IMAGE
+        );
+
+        assertThat(standings.getLeagueSeasonId()).isEqualTo(10L);
+        assertThat(standings.getStandingsType()).isEqualTo(LeagueSeasonStandingsType.IMAGE);
+    }
+
+    @Test
+    void 수동_관리_리그는_외부_데이터_타입으로_순위_관리를_생성할_수_없다() {
+        LeagueSeason leagueSeason = season(manualLeague(1L));
+
+        assertThatThrownBy(() -> LeagueSeasonStandings.from(
+                leagueSeason,
+                LeagueSeasonStandingsType.EXTERNAL_DATA
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+    }
+
+    @Test
+    void 외부_연동_리그는_외부_데이터_타입으로_변경할_수_있다() {
+        LeagueSeason leagueSeason = season(betsLeague(1L));
+        LeagueSeasonStandings standings = LeagueSeasonStandings.from(
+                leagueSeason,
+                LeagueSeasonStandingsType.IMAGE
+        );
+
+        standings.updateStandingsType(leagueSeason, LeagueSeasonStandingsType.EXTERNAL_DATA);
+
+        assertThat(standings.getStandingsType()).isEqualTo(LeagueSeasonStandingsType.EXTERNAL_DATA);
+    }
+
+    @Test
+    void 수동_관리_리그는_외부_데이터_타입으로_변경할_수_없다() {
+        LeagueSeason leagueSeason = season(manualLeague(1L));
+        LeagueSeasonStandings standings = LeagueSeasonStandings.from(
+                leagueSeason,
+                LeagueSeasonStandingsType.IMAGE
+        );
+
+        assertThatThrownBy(() -> standings.updateStandingsType(
+                leagueSeason,
+                LeagueSeasonStandingsType.EXTERNAL_DATA
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        assertThat(standings.getStandingsType()).isEqualTo(LeagueSeasonStandingsType.IMAGE);
+    }
+
+    @Test
+    void 순위_관리_타입이_null이면_변경할_수_없다() {
+        LeagueSeason leagueSeason = season(betsLeague(1L));
+        LeagueSeasonStandings standings = LeagueSeasonStandings.from(
+                leagueSeason,
+                LeagueSeasonStandingsType.IMAGE
+        );
+
+        assertThatThrownBy(() -> standings.updateStandingsType(leagueSeason, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+    }
+
+    private LeagueSeason season(League league) {
+        LeagueSeason leagueSeason = LeagueSeason.create(
+                league.getId(),
+                "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                true
+        );
+
+        ReflectionTestUtils.setField(leagueSeason, "id", 10L);
+        ReflectionTestUtils.setField(leagueSeason, "league", league);
+
+        return leagueSeason;
+    }
+
+    private League manualLeague(Long id) {
+        return League.builder()
+                .id(id)
+                .kName("수동 리그")
+                .dataOrigin(DataOrigin.MANUAL)
+                .build();
+    }
+
+    private League betsLeague(Long id) {
+        return League.builder()
+                .id(id)
+                .kName("외부 리그")
+                .dataOrigin(DataOrigin.BETS)
+                .build();
+    }
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeasonTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/league/entity/LeagueSeasonTest.java
@@ -1,0 +1,172 @@
+package com.scorenow.scorenow_api.domain.league.entity;
+
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LeagueSeasonTest {
+
+    @Test
+    void 리그_시즌을_생성한다() {
+        LeagueSeason leagueSeason = LeagueSeason.create(
+                1L,
+                "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                true
+        );
+
+        assertThat(leagueSeason.getLeagueId()).isEqualTo(1L);
+        assertThat(leagueSeason.getSeasonName()).isEqualTo("2025/26");
+        assertThat(leagueSeason.getSeasonStartAt()).isEqualTo(LocalDate.of(2025, 8, 1));
+        assertThat(leagueSeason.getSeasonEndAt()).isEqualTo(LocalDate.of(2026, 5, 31));
+        assertThat(leagueSeason.isCurrent()).isTrue();
+        assertThat(leagueSeason.isActive()).isTrue();
+    }
+
+    @Test
+    void 리그_ID가_null이면_생성에_실패한다() {
+        assertThatThrownBy(() -> LeagueSeason.create(
+                null,
+                "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                false
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+    }
+
+    @Test
+    void 시즌명이_null이거나_blank이면_생성에_실패한다() {
+        assertThatThrownBy(() -> LeagueSeason.create(
+                1L,
+                " ",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                false
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+    }
+
+    @Test
+    void 시즌_시작일이_종료일보다_늦으면_생성에_실패한다() {
+        assertThatThrownBy(() -> LeagueSeason.create(
+                1L,
+                "2025/26",
+                LocalDate.of(2026, 6, 1),
+                LocalDate.of(2026, 5, 31),
+                false
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+    }
+
+    @Test
+    void 시즌명을_수정한다() {
+        LeagueSeason leagueSeason = createSeason(1L, "2025/26");
+
+        leagueSeason.updateSeasonName("2026/27");
+
+        assertThat(leagueSeason.getSeasonName()).isEqualTo("2026/27");
+    }
+
+    @Test
+    void 시즌명을_blank로_수정하면_실패한다() {
+        LeagueSeason leagueSeason = createSeason(1L, "2025/26");
+
+        assertThatThrownBy(() -> leagueSeason.updateSeasonName(" "))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+    }
+
+    @Test
+    void 시즌_일정을_수정한다() {
+        LeagueSeason leagueSeason = createSeason(1L, "2025/26");
+
+        leagueSeason.updatePeriod(
+                LocalDate.of(2025, 7, 1),
+                LocalDate.of(2026, 6, 30)
+        );
+
+        assertThat(leagueSeason.getSeasonStartAt()).isEqualTo(LocalDate.of(2025, 7, 1));
+        assertThat(leagueSeason.getSeasonEndAt()).isEqualTo(LocalDate.of(2026, 6, 30));
+    }
+
+    @Test
+    void 시즌_일정을_잘못_수정하면_실패한다() {
+        LeagueSeason leagueSeason = createSeason(1L, "2025/26");
+
+        assertThatThrownBy(() -> leagueSeason.updatePeriod(
+                LocalDate.of(2026, 7, 1),
+                LocalDate.of(2026, 6, 30)
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+    }
+
+    @Test
+    void 시즌을_비활성화하면_현재_시즌도_해제된다() {
+        LeagueSeason leagueSeason = LeagueSeason.create(
+                1L,
+                "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                true
+        );
+
+        leagueSeason.deactivate();
+
+        assertThat(leagueSeason.isActive()).isFalse();
+        assertThat(leagueSeason.isCurrent()).isFalse();
+    }
+
+    @Test
+    void 시즌_기간_겹침을_판단한다() {
+        LeagueSeason leagueSeason = createSeason(1L, "2025/26");
+
+        assertThat(leagueSeason.overlapsWith(
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2025, 8, 1)
+        )).isTrue();
+        assertThat(leagueSeason.overlapsWith(
+                LocalDate.of(2026, 5, 31),
+                LocalDate.of(2026, 6, 1)
+        )).isTrue();
+        assertThat(leagueSeason.overlapsWith(
+                LocalDate.of(2026, 6, 1),
+                LocalDate.of(2026, 6, 30)
+        )).isFalse();
+    }
+
+    @Test
+    void 같은_ID인지_판단한다() {
+        LeagueSeason leagueSeason = createSeason(1L, "2025/26");
+        ReflectionTestUtils.setField(leagueSeason, "id", 10L);
+
+        assertThat(leagueSeason.isSameId(10L)).isTrue();
+        assertThat(leagueSeason.isSameId(11L)).isFalse();
+    }
+
+    private LeagueSeason createSeason(Long leagueId, String seasonName) {
+        return LeagueSeason.create(
+                leagueId,
+                seasonName,
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                false
+        );
+    }
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/league/mapper/LeagueSeasonStandingsMapperTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/league/mapper/LeagueSeasonStandingsMapperTest.java
@@ -4,11 +4,15 @@ import com.scorenow.scorenow_api.domain.common.enums.DataOrigin;
 import com.scorenow.scorenow_api.domain.league.document.LeagueSeasonStandingsDataDocument;
 import com.scorenow.scorenow_api.domain.league.dto.LeagueSeasonStandingsSyncTarget;
 import com.scorenow.scorenow_api.external.betsapi.dto.BetsStandingsResponse;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LeagueSeasonStandingsMapperTest {
 
@@ -94,6 +98,45 @@ class LeagueSeasonStandingsMapperTest {
     }
 
     @Test
+    void tables_내부_null_요소는_무시하고_첫번째_유효한_table을_변환한다() {
+        BetsStandingsResponse.Table table = table(List.of(row(
+                1,
+                0,
+                10,
+                5,
+                3,
+                30,
+                12,
+                35,
+                null,
+                team("101", "Liverpool", "liverpool.png", "gb")
+        )));
+        BetsStandingsResponse.Overall overall = new BetsStandingsResponse.Overall();
+        overall.setTables(Arrays.asList(null, table));
+
+        LeagueSeasonStandingsDataDocument document = mapper.toDocument(
+                result(season("2025/26", 1L, 2L), overall),
+                syncTarget()
+        );
+
+        assertThat(document.getStandingsTable().getRows()).hasSize(1);
+        assertThat(document.getStandingsTable().getRows().get(0).getTeam().getApiTeamId()).isEqualTo("101");
+    }
+
+    @Test
+    void tables_내부에_null만_있으면_standingsTable은_null이다() {
+        BetsStandingsResponse.Overall overall = new BetsStandingsResponse.Overall();
+        overall.setTables(Arrays.asList(null, null));
+
+        LeagueSeasonStandingsDataDocument document = mapper.toDocument(
+                result(season("2025/26", 1L, 2L), overall),
+                syncTarget()
+        );
+
+        assertThat(document.getStandingsTable()).isNull();
+    }
+
+    @Test
     void rows가_null이면_빈_리스트로_변환한다() {
         LeagueSeasonStandingsDataDocument document = mapper.toDocument(
                 result(season("2025/26", 1L, 2L), overall(table(null))),
@@ -101,6 +144,30 @@ class LeagueSeasonStandingsMapperTest {
         );
 
         assertThat(document.getStandingsTable().getRows()).isEmpty();
+    }
+
+    @Test
+    void rows_내부_null_요소는_무시한다() {
+        BetsStandingsResponse.Row row = row(
+                1,
+                0,
+                10,
+                5,
+                3,
+                30,
+                12,
+                35,
+                null,
+                team("101", "Liverpool", "liverpool.png", "gb")
+        );
+
+        LeagueSeasonStandingsDataDocument document = mapper.toDocument(
+                result(season("2025/26", 1L, 2L), overall(table(Arrays.asList(null, row)))),
+                syncTarget()
+        );
+
+        assertThat(document.getStandingsTable().getRows()).hasSize(1);
+        assertThat(document.getStandingsTable().getRows().get(0).getTeam().getApiTeamId()).isEqualTo("101");
     }
 
     @Test
@@ -133,6 +200,14 @@ class LeagueSeasonStandingsMapperTest {
         assertThat(standingsRow.getGoalDifference()).isZero();
         assertThat(standingsRow.getPromotion()).isNull();
         assertThat(standingsRow.getTeam()).isNull();
+    }
+
+    @Test
+    void result가_null이면_변환에_실패한다() {
+        assertThatThrownBy(() -> mapper.toDocument(null, syncTarget()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
     }
 
     private LeagueSeasonStandingsSyncTarget syncTarget() {

--- a/src/test/java/com/scorenow/scorenow_api/domain/league/mapper/LeagueSeasonStandingsMapperTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/league/mapper/LeagueSeasonStandingsMapperTest.java
@@ -1,0 +1,223 @@
+package com.scorenow.scorenow_api.domain.league.mapper;
+
+import com.scorenow.scorenow_api.domain.common.enums.DataOrigin;
+import com.scorenow.scorenow_api.domain.league.document.LeagueSeasonStandingsDataDocument;
+import com.scorenow.scorenow_api.domain.league.dto.LeagueSeasonStandingsSyncTarget;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsStandingsResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LeagueSeasonStandingsMapperTest {
+
+    private final LeagueSeasonStandingsMapper mapper = new LeagueSeasonStandingsMapper();
+
+    @Test
+    void 외부_순위_응답을_Mongo_문서로_변환한다() {
+        BetsStandingsResponse.Result result = result(
+                season("2025/26", 1_754_006_400L, 1_779_897_600L),
+                overall(table(List.of(row(
+                        1,
+                        0,
+                        10,
+                        5,
+                        3,
+                        30,
+                        12,
+                        35,
+                        promotion("Champions League", "CL"),
+                        team("101", "Liverpool", "liverpool.png", "gb")
+                ))))
+        );
+
+        LeagueSeasonStandingsDataDocument document = mapper.toDocument(result, syncTarget());
+
+        assertThat(document.getLeagueId()).isEqualTo(1L);
+        assertThat(document.getApiLeagueId()).isEqualTo("94");
+        assertThat(document.getDataOrigin()).isEqualTo(DataOrigin.BETS);
+        assertThat(document.getLeagueSeasonId()).isEqualTo(10L);
+        assertThat(document.getExternalSeasonName()).isEqualTo("2025/26");
+        assertThat(document.getExternalSeasonStartAt()).isEqualTo(1_754_006_400L);
+        assertThat(document.getExternalSeasonEndAt()).isEqualTo(1_779_897_600L);
+
+        LeagueSeasonStandingsDataDocument.StandingsTable standingsTable = document.getStandingsTable();
+        assertThat(standingsTable.getName()).isEqualTo("overall");
+        assertThat(standingsTable.getRows()).hasSize(1);
+
+        LeagueSeasonStandingsDataDocument.StandingsRow standingsRow = standingsTable.getRows().get(0);
+        assertThat(standingsRow.getPosition()).isEqualTo(1);
+        assertThat(standingsRow.getPlayed()).isEqualTo(18);
+        assertThat(standingsRow.getWin()).isEqualTo(10);
+        assertThat(standingsRow.getDraw()).isEqualTo(5);
+        assertThat(standingsRow.getLoss()).isEqualTo(3);
+        assertThat(standingsRow.getGoalDifference()).isEqualTo(18);
+        assertThat(standingsRow.getPoints()).isEqualTo(35);
+        assertThat(standingsRow.getPromotion().getShortName()).isEqualTo("CL");
+        assertThat(standingsRow.getTeam().getApiTeamId()).isEqualTo("101");
+    }
+
+    @Test
+    void 외부_시즌이_null이어도_문서로_변환한다() {
+        LeagueSeasonStandingsDataDocument document = mapper.toDocument(
+                result(null, overall(table(List.of()))),
+                syncTarget()
+        );
+
+        assertThat(document.getExternalSeasonName()).isNull();
+        assertThat(document.getExternalSeasonStartAt()).isNull();
+        assertThat(document.getExternalSeasonEndAt()).isNull();
+    }
+
+    @Test
+    void overall이_null이면_standingsTable은_null이다() {
+        LeagueSeasonStandingsDataDocument document = mapper.toDocument(
+                result(season("2025/26", 1L, 2L), null),
+                syncTarget()
+        );
+
+        assertThat(document.getStandingsTable()).isNull();
+    }
+
+    @Test
+    void tables가_비어있으면_standingsTable은_null이다() {
+        BetsStandingsResponse.Overall overall = new BetsStandingsResponse.Overall();
+        overall.setTables(List.of());
+
+        LeagueSeasonStandingsDataDocument document = mapper.toDocument(
+                result(season("2025/26", 1L, 2L), overall),
+                syncTarget()
+        );
+
+        assertThat(document.getStandingsTable()).isNull();
+    }
+
+    @Test
+    void rows가_null이면_빈_리스트로_변환한다() {
+        LeagueSeasonStandingsDataDocument document = mapper.toDocument(
+                result(season("2025/26", 1L, 2L), overall(table(null))),
+                syncTarget()
+        );
+
+        assertThat(document.getStandingsTable().getRows()).isEmpty();
+    }
+
+    @Test
+    void row의_optional_필드가_null이어도_변환한다() {
+        BetsStandingsResponse.Row row = row(
+                1,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        LeagueSeasonStandingsDataDocument document = mapper.toDocument(
+                result(season("2025/26", 1L, 2L), overall(table(List.of(row)))),
+                syncTarget()
+        );
+
+        LeagueSeasonStandingsDataDocument.StandingsRow standingsRow =
+                document.getStandingsTable().getRows().get(0);
+
+        assertThat(standingsRow.getPlayed()).isZero();
+        assertThat(standingsRow.getWin()).isZero();
+        assertThat(standingsRow.getDraw()).isZero();
+        assertThat(standingsRow.getLoss()).isZero();
+        assertThat(standingsRow.getGoalDifference()).isZero();
+        assertThat(standingsRow.getPromotion()).isNull();
+        assertThat(standingsRow.getTeam()).isNull();
+    }
+
+    private LeagueSeasonStandingsSyncTarget syncTarget() {
+        return LeagueSeasonStandingsSyncTarget.builder()
+                .leagueSeasonStandingsId(100L)
+                .leagueSeasonId(10L)
+                .leagueId(1L)
+                .dataOrigin(DataOrigin.BETS)
+                .apiLeagueId("94")
+                .build();
+    }
+
+    private BetsStandingsResponse.Result result(
+            BetsStandingsResponse.Season season,
+            BetsStandingsResponse.Overall overall
+    ) {
+        BetsStandingsResponse.Result result = new BetsStandingsResponse.Result();
+        result.setSeason(season);
+        result.setOverall(overall);
+        return result;
+    }
+
+    private BetsStandingsResponse.Season season(String name, Long startTime, Long endTime) {
+        BetsStandingsResponse.Season season = new BetsStandingsResponse.Season();
+        season.setName(name);
+        season.setStartTime(startTime);
+        season.setEndTime(endTime);
+        return season;
+    }
+
+    private BetsStandingsResponse.Overall overall(BetsStandingsResponse.Table table) {
+        BetsStandingsResponse.Overall overall = new BetsStandingsResponse.Overall();
+        overall.setTables(List.of(table));
+        return overall;
+    }
+
+    private BetsStandingsResponse.Table table(List<BetsStandingsResponse.Row> rows) {
+        BetsStandingsResponse.Table table = new BetsStandingsResponse.Table();
+        table.setName("overall");
+        table.setGroupName("A");
+        table.setCurrentRound(10);
+        table.setMaxRounds(38);
+        table.setRows(rows);
+        return table;
+    }
+
+    private BetsStandingsResponse.Row row(
+            Integer position,
+            Integer positionChange,
+            Integer win,
+            Integer draw,
+            Integer loss,
+            Integer goalsFor,
+            Integer goalsAgainst,
+            Integer points,
+            BetsStandingsResponse.Promotion promotion,
+            BetsStandingsResponse.Team team
+    ) {
+        BetsStandingsResponse.Row row = new BetsStandingsResponse.Row();
+        row.setPos(position);
+        row.setChange(positionChange);
+        row.setWin(win);
+        row.setDraw(draw);
+        row.setLoss(loss);
+        row.setGoalsFor(goalsFor);
+        row.setGoalsAgainst(goalsAgainst);
+        row.setPoints(points);
+        row.setPromotion(promotion);
+        row.setTeam(team);
+        return row;
+    }
+
+    private BetsStandingsResponse.Promotion promotion(String name, String shortName) {
+        BetsStandingsResponse.Promotion promotion = new BetsStandingsResponse.Promotion();
+        promotion.setName(name);
+        promotion.setShortName(shortName);
+        return promotion;
+    }
+
+    private BetsStandingsResponse.Team team(String id, String name, String imageId, String countryCode) {
+        BetsStandingsResponse.Team team = new BetsStandingsResponse.Team();
+        team.setId(id);
+        team.setName(name);
+        team.setImageId(imageId);
+        team.setCc(countryCode);
+        return team;
+    }
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonServiceTest.java
@@ -1,0 +1,348 @@
+package com.scorenow.scorenow_api.domain.league.service;
+
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonCreateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonSearchCondition;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonUpdateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.response.AdminLeagueSeasonResponse;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeason;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueRepository;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueSeasonRepository;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class AdminLeagueSeasonServiceTest {
+
+    @Mock
+    private LeagueSeasonRepository leagueSeasonRepository;
+
+    @Mock
+    private LeagueRepository leagueRepository;
+
+    @InjectMocks
+    private AdminLeagueSeasonService adminLeagueSeasonService;
+
+    @Test
+    void 리그_시즌을_생성한다() {
+        given(leagueRepository.existsById(1L)).willReturn(true);
+        given(leagueSeasonRepository.existsByLeagueIdAndSeasonName(1L, "2025/26")).willReturn(false);
+        given(leagueSeasonRepository.findAllByLeagueIdAndIsActiveTrue(1L)).willReturn(List.of());
+
+        adminLeagueSeasonService.createLeagueSeason(createRequest(
+                1L,
+                " 2025/26 ",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                false
+        ));
+
+        ArgumentCaptor<LeagueSeason> captor = ArgumentCaptor.forClass(LeagueSeason.class);
+        then(leagueSeasonRepository).should().save(captor.capture());
+
+        LeagueSeason saved = captor.getValue();
+        assertThat(saved.getLeagueId()).isEqualTo(1L);
+        assertThat(saved.getSeasonName()).isEqualTo("2025/26");
+        assertThat(saved.isCurrent()).isFalse();
+    }
+
+    @Test
+    void 존재하지_않는_리그면_시즌_생성에_실패한다() {
+        given(leagueRepository.existsById(1L)).willReturn(false);
+
+        assertThatThrownBy(() -> adminLeagueSeasonService.createLeagueSeason(createRequest(
+                1L,
+                "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                false
+        )))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LEAGUE_NOT_FOUND);
+
+        then(leagueSeasonRepository).should(never()).save(any());
+    }
+
+    @Test
+    void 동일한_리그에_같은_시즌명이_있으면_시즌_생성에_실패한다() {
+        given(leagueRepository.existsById(1L)).willReturn(true);
+        given(leagueSeasonRepository.existsByLeagueIdAndSeasonName(1L, "2025/26")).willReturn(true);
+
+        assertThatThrownBy(() -> adminLeagueSeasonService.createLeagueSeason(createRequest(
+                1L,
+                "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                false
+        )))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        then(leagueSeasonRepository).should(never()).save(any());
+    }
+
+    @Test
+    void 시즌_시작일이_종료일보다_늦으면_시즌_생성에_실패한다() {
+        given(leagueRepository.existsById(1L)).willReturn(true);
+        given(leagueSeasonRepository.existsByLeagueIdAndSeasonName(1L, "2025/26")).willReturn(false);
+
+        assertThatThrownBy(() -> adminLeagueSeasonService.createLeagueSeason(createRequest(
+                1L,
+                "2025/26",
+                LocalDate.of(2026, 6, 1),
+                LocalDate.of(2026, 5, 31),
+                false
+        )))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        then(leagueSeasonRepository).should(never()).save(any());
+    }
+
+    @Test
+    void 시즌_일정이_겹치면_시즌_생성에_실패한다() {
+        LeagueSeason existingSeason = season(1L, 1L, "2024/25",
+                LocalDate.of(2024, 8, 1),
+                LocalDate.of(2025, 5, 31),
+                false);
+
+        given(leagueRepository.existsById(1L)).willReturn(true);
+        given(leagueSeasonRepository.existsByLeagueIdAndSeasonName(1L, "2025/26")).willReturn(false);
+        given(leagueSeasonRepository.findAllByLeagueIdAndIsActiveTrue(1L)).willReturn(List.of(existingSeason));
+
+        assertThatThrownBy(() -> adminLeagueSeasonService.createLeagueSeason(createRequest(
+                1L,
+                "2025/26",
+                LocalDate.of(2025, 5, 1),
+                LocalDate.of(2026, 5, 31),
+                false
+        )))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        then(leagueSeasonRepository).should(never()).save(any());
+    }
+
+    @Test
+    void 현재_시즌으로_생성하면_기존_현재_시즌을_해제한다() {
+        LeagueSeason currentSeason = season(1L, 1L, "2024/25",
+                LocalDate.of(2024, 8, 1),
+                LocalDate.of(2025, 5, 31),
+                true);
+
+        given(leagueRepository.existsById(1L)).willReturn(true);
+        given(leagueSeasonRepository.existsByLeagueIdAndSeasonName(1L, "2025/26")).willReturn(false);
+        given(leagueSeasonRepository.findAllByLeagueIdAndIsActiveTrue(1L)).willReturn(List.of(currentSeason));
+        given(leagueSeasonRepository.findCurrentSeasonByLeagueId(1L)).willReturn(Optional.of(currentSeason));
+
+        adminLeagueSeasonService.createLeagueSeason(createRequest(
+                1L,
+                "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                true
+        ));
+
+        assertThat(currentSeason.isCurrent()).isFalse();
+        then(leagueSeasonRepository).should().save(any(LeagueSeason.class));
+    }
+
+    @Test
+    void 리그_시즌을_검색한다() {
+        PageRequest pageable = PageRequest.of(0, 20);
+        LeagueSeasonSearchCondition condition = new LeagueSeasonSearchCondition();
+        condition.setLeagueId(1L);
+        condition.setLeagueName(" Premier ");
+        AdminLeagueSeasonResponse response = new AdminLeagueSeasonResponse(
+                1L,
+                "Premier League",
+                10L,
+                "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                true
+        );
+        given(leagueSeasonRepository.searchLeagueSeasons(1L, "Premier", pageable))
+                .willReturn(new PageImpl<>(List.of(response), pageable, 1));
+
+        Page<AdminLeagueSeasonResponse> result = adminLeagueSeasonService.searchLeagueSeasons(condition, pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getLeagueSeasonId()).isEqualTo(10L);
+    }
+
+    @Test
+    void 리그_시즌을_부분_수정한다() {
+        LeagueSeason target = season(10L, 1L, "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                false);
+
+        given(leagueSeasonRepository.findByIdAndIsActiveTrue(10L)).willReturn(Optional.of(target));
+        given(leagueSeasonRepository.findAllByLeagueIdAndIsActiveTrue(1L)).willReturn(List.of(target));
+
+        adminLeagueSeasonService.updateLeagueSeason(10L, updateRequest(
+                "2025/2026",
+                LocalDate.of(2025, 7, 1),
+                LocalDate.of(2026, 6, 30),
+                null
+        ));
+
+        assertThat(target.getSeasonName()).isEqualTo("2025/2026");
+        assertThat(target.getSeasonStartAt()).isEqualTo(LocalDate.of(2025, 7, 1));
+        assertThat(target.getSeasonEndAt()).isEqualTo(LocalDate.of(2026, 6, 30));
+    }
+
+    @Test
+    void 수정_시_시즌명이_중복되면_실패한다() {
+        LeagueSeason target = season(10L, 1L, "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                false);
+        LeagueSeason other = season(11L, 1L, "2026/27",
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2027, 5, 31),
+                false);
+
+        given(leagueSeasonRepository.findByIdAndIsActiveTrue(10L)).willReturn(Optional.of(target));
+        given(leagueSeasonRepository.findAllByLeagueIdAndIsActiveTrue(1L)).willReturn(List.of(target, other));
+
+        assertThatThrownBy(() -> adminLeagueSeasonService.updateLeagueSeason(10L, updateRequest(
+                "2026/27",
+                null,
+                null,
+                null
+        )))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+    }
+
+    @Test
+    void 수정_시_시즌_일정이_겹치면_실패한다() {
+        LeagueSeason target = season(10L, 1L, "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                false);
+        LeagueSeason other = season(11L, 1L, "2026/27",
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2027, 5, 31),
+                false);
+
+        given(leagueSeasonRepository.findByIdAndIsActiveTrue(10L)).willReturn(Optional.of(target));
+        given(leagueSeasonRepository.findAllByLeagueIdAndIsActiveTrue(1L)).willReturn(List.of(target, other));
+
+        assertThatThrownBy(() -> adminLeagueSeasonService.updateLeagueSeason(10L, updateRequest(
+                null,
+                LocalDate.of(2026, 7, 1),
+                LocalDate.of(2026, 9, 1),
+                null
+        )))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+    }
+
+    @Test
+    void 현재_시즌으로_수정하면_기존_현재_시즌을_해제한다() {
+        LeagueSeason target = season(10L, 1L, "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                false);
+        LeagueSeason otherCurrent = season(11L, 1L, "2024/25",
+                LocalDate.of(2024, 8, 1),
+                LocalDate.of(2025, 5, 31),
+                true);
+
+        given(leagueSeasonRepository.findByIdAndIsActiveTrue(10L)).willReturn(Optional.of(target));
+        given(leagueSeasonRepository.findAllByLeagueIdAndIsActiveTrue(1L)).willReturn(List.of(target, otherCurrent));
+
+        adminLeagueSeasonService.updateLeagueSeason(10L, updateRequest(null, null, null, true));
+
+        assertThat(target.isCurrent()).isTrue();
+        assertThat(otherCurrent.isCurrent()).isFalse();
+    }
+
+    @Test
+    void 리그_시즌을_삭제하면_비활성화하고_현재_시즌을_해제한다() {
+        LeagueSeason target = season(10L, 1L, "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                true);
+        given(leagueSeasonRepository.findByIdAndIsActiveTrue(10L)).willReturn(Optional.of(target));
+
+        adminLeagueSeasonService.deleteLeagueSeason(10L);
+
+        assertThat(target.isActive()).isFalse();
+        assertThat(target.isCurrent()).isFalse();
+    }
+
+    private LeagueSeasonCreateRequest createRequest(
+            Long leagueId,
+            String seasonName,
+            LocalDate startAt,
+            LocalDate endAt,
+            boolean current
+    ) {
+        LeagueSeasonCreateRequest request = mock(LeagueSeasonCreateRequest.class);
+        lenient().when(request.getLeagueId()).thenReturn(leagueId);
+        lenient().when(request.getSeasonName()).thenReturn(seasonName);
+        lenient().when(request.getSeasonStartAt()).thenReturn(startAt);
+        lenient().when(request.getSeasonEndAt()).thenReturn(endAt);
+        lenient().when(request.isCurrent()).thenReturn(current);
+        return request;
+    }
+
+    private LeagueSeasonUpdateRequest updateRequest(
+            String seasonName,
+            LocalDate startAt,
+            LocalDate endAt,
+            Boolean current
+    ) {
+        LeagueSeasonUpdateRequest request = mock(LeagueSeasonUpdateRequest.class);
+        lenient().when(request.getSeasonName()).thenReturn(seasonName);
+        lenient().when(request.getSeasonStartAt()).thenReturn(startAt);
+        lenient().when(request.getSeasonEndAt()).thenReturn(endAt);
+        lenient().when(request.getIsCurrent()).thenReturn(current);
+        return request;
+    }
+
+    private LeagueSeason season(
+            Long id,
+            Long leagueId,
+            String seasonName,
+            LocalDate startAt,
+            LocalDate endAt,
+            boolean current
+    ) {
+        LeagueSeason leagueSeason = LeagueSeason.create(leagueId, seasonName, startAt, endAt, current);
+        ReflectionTestUtils.setField(leagueSeason, "id", id);
+        return leagueSeason;
+    }
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonServiceTest.java
@@ -159,7 +159,7 @@ class AdminLeagueSeasonServiceTest {
         given(leagueRepository.existsById(1L)).willReturn(true);
         given(leagueSeasonRepository.existsByLeagueIdAndSeasonName(1L, "2025/26")).willReturn(false);
         given(leagueSeasonRepository.findAllByLeagueIdAndIsActiveTrue(1L)).willReturn(List.of(currentSeason));
-        given(leagueSeasonRepository.findCurrentSeasonByLeagueId(1L)).willReturn(Optional.of(currentSeason));
+        given(leagueSeasonRepository.findCurrentSeasonByLeagueId(1L)).willReturn(List.of(currentSeason));
 
         adminLeagueSeasonService.createLeagueSeason(createRequest(
                 1L,

--- a/src/test/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonStandingsServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonStandingsServiceTest.java
@@ -1,0 +1,251 @@
+package com.scorenow.scorenow_api.domain.league.service;
+
+import com.scorenow.scorenow_api.domain.common.enums.DataOrigin;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsCreateRequest;
+import com.scorenow.scorenow_api.domain.league.entity.League;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueExternalMapping;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeason;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeasonStandings;
+import com.scorenow.scorenow_api.domain.league.entity.LeagueSeasonStandingsType;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueExternalMappingRepository;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueSeasonRepository;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueSeasonStandingsMongoRepository;
+import com.scorenow.scorenow_api.domain.league.repository.LeagueSeasonStandingsRepository;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import com.scorenow.scorenow_api.global.infra.storage.FileStorage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class AdminLeagueSeasonStandingsServiceTest {
+
+    @Mock
+    private LeagueSeasonRepository leagueSeasonRepository;
+
+    @Mock
+    private LeagueExternalMappingRepository leagueExternalMappingRepository;
+
+    @Mock
+    private LeagueSeasonStandingsRepository leagueSeasonStandingsRepository;
+
+    @Mock
+    private LeagueSeasonStandingsMongoRepository leagueSeasonStandingsMongoRepository;
+
+    @Mock
+    private LeagueSeasonStandingsSyncService leagueSeasonStandingsSyncService;
+
+    @Mock
+    private FileStorage fileStorage;
+
+    @InjectMocks
+    private AdminLeagueSeasonStandingsService service;
+
+    @Test
+    void 이미지_타입_리그_시즌_순위_관리를_등록한다() {
+        LeagueSeason leagueSeason = season(10L, manualLeague(1L));
+        given(leagueSeasonRepository.findByIdAndIsActiveTrue(10L)).willReturn(Optional.of(leagueSeason));
+        given(leagueSeasonStandingsRepository.existsByLeagueSeasonId(10L)).willReturn(false);
+
+        service.createLeagueSeasonStandings(createRequest(10L, LeagueSeasonStandingsType.IMAGE));
+
+        ArgumentCaptor<LeagueSeasonStandings> captor = ArgumentCaptor.forClass(LeagueSeasonStandings.class);
+        then(leagueSeasonStandingsRepository).should().save(captor.capture());
+        assertThat(captor.getValue().getLeagueSeasonId()).isEqualTo(10L);
+        assertThat(captor.getValue().getStandingsType()).isEqualTo(LeagueSeasonStandingsType.IMAGE);
+    }
+
+    @Test
+    void 비활성_또는_존재하지_않는_시즌이면_순위_관리_등록에_실패한다() {
+        given(leagueSeasonRepository.findByIdAndIsActiveTrue(10L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createLeagueSeasonStandings(
+                createRequest(10L, LeagueSeasonStandingsType.IMAGE)
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        then(leagueSeasonStandingsRepository).should(never()).save(any());
+    }
+
+    @Test
+    void 이미_등록된_시즌이면_순위_관리_등록에_실패한다() {
+        LeagueSeason leagueSeason = season(10L, manualLeague(1L));
+        given(leagueSeasonRepository.findByIdAndIsActiveTrue(10L)).willReturn(Optional.of(leagueSeason));
+        given(leagueSeasonStandingsRepository.existsByLeagueSeasonId(10L)).willReturn(true);
+
+        assertThatThrownBy(() -> service.createLeagueSeasonStandings(
+                createRequest(10L, LeagueSeasonStandingsType.IMAGE)
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LEAGUE_ALREADY_EXISTS);
+
+        then(leagueSeasonStandingsRepository).should(never()).save(any());
+    }
+
+    @Test
+    void 외부_데이터_타입인데_외부_매핑이_없으면_등록에_실패한다() {
+        LeagueSeason leagueSeason = season(10L, betsLeague(1L));
+        given(leagueSeasonRepository.findByIdAndIsActiveTrue(10L)).willReturn(Optional.of(leagueSeason));
+        given(leagueSeasonStandingsRepository.existsByLeagueSeasonId(10L)).willReturn(false);
+        given(leagueExternalMappingRepository.findByDataOriginAndInternalLeagueId(DataOrigin.BETS, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createLeagueSeasonStandings(
+                createRequest(10L, LeagueSeasonStandingsType.EXTERNAL_DATA)
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        then(leagueSeasonStandingsRepository).should(never()).save(any());
+    }
+
+    @Test
+    void 외부_데이터_타입_리그_시즌_순위_관리를_등록한다() {
+        LeagueSeason leagueSeason = season(10L, betsLeague(1L));
+        given(leagueSeasonRepository.findByIdAndIsActiveTrue(10L)).willReturn(Optional.of(leagueSeason));
+        given(leagueSeasonStandingsRepository.existsByLeagueSeasonId(10L)).willReturn(false);
+        given(leagueExternalMappingRepository.findByDataOriginAndInternalLeagueId(DataOrigin.BETS, 1L))
+                .willReturn(Optional.of(LeagueExternalMapping.of(DataOrigin.BETS, "94", 1L, true)));
+
+        service.createLeagueSeasonStandings(createRequest(10L, LeagueSeasonStandingsType.EXTERNAL_DATA));
+
+        then(leagueSeasonStandingsRepository).should().save(any(LeagueSeasonStandings.class));
+    }
+
+    @Test
+    void 이미지_타입_순위_이미지를_업로드한다() {
+        LeagueSeasonStandings standings = standings(10L, LeagueSeasonStandingsType.IMAGE);
+        MultipartFile image = mock(MultipartFile.class);
+        given(leagueSeasonStandingsRepository.findByLeagueSeasonId(10L)).willReturn(Optional.of(standings));
+        given(fileStorage.uploadFile(image)).willReturn("https://cdn.example.com/standing.png");
+
+        service.uploadLeagueSeasonStandingsImage(10L, image);
+
+        assertThat(standings.getImageUrl()).isEqualTo("https://cdn.example.com/standing.png");
+    }
+
+    @Test
+    void 이미지_타입이_아니면_순위_이미지_업로드에_실패한다() {
+        given(leagueSeasonStandingsRepository.findByLeagueSeasonId(10L))
+                .willReturn(Optional.of(standings(10L, LeagueSeasonStandingsType.EXTERNAL_DATA)));
+
+        assertThatThrownBy(() -> service.uploadLeagueSeasonStandingsImage(10L, mock(MultipartFile.class)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        then(fileStorage).should(never()).uploadFile(any());
+    }
+
+    @Test
+    void 외부_데이터_타입이면_수동_동기화를_호출한다() {
+        given(leagueSeasonStandingsRepository.findByLeagueSeasonId(10L))
+                .willReturn(Optional.of(standings(10L, LeagueSeasonStandingsType.EXTERNAL_DATA)));
+
+        service.syncLeagueSeasonStandingsData(10L);
+
+        then(leagueSeasonStandingsSyncService).should().sync(10L);
+    }
+
+    @Test
+    void 이미지_타입이면_수동_동기화에_실패한다() {
+        given(leagueSeasonStandingsRepository.findByLeagueSeasonId(10L))
+                .willReturn(Optional.of(standings(10L, LeagueSeasonStandingsType.IMAGE)));
+
+        assertThatThrownBy(() -> service.syncLeagueSeasonStandingsData(10L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        then(leagueSeasonStandingsSyncService).should(never()).sync(any());
+    }
+
+    @Test
+    void 외부_데이터_타입_순위_관리를_삭제하면_Mongo_문서도_삭제한다() {
+        LeagueSeasonStandings standings = standings(10L, LeagueSeasonStandingsType.EXTERNAL_DATA);
+        given(leagueSeasonStandingsRepository.findByLeagueSeasonId(10L)).willReturn(Optional.of(standings));
+
+        service.deleteLeagueSeasonStandings(10L);
+
+        then(leagueSeasonStandingsMongoRepository).should().deleteByLeagueSeasonId(10L);
+        then(leagueSeasonStandingsRepository).should().delete(standings);
+    }
+
+    @Test
+    void 이미지_타입_순위_관리를_삭제하면_Mongo_문서는_삭제하지_않는다() {
+        LeagueSeasonStandings standings = standings(10L, LeagueSeasonStandingsType.IMAGE);
+        given(leagueSeasonStandingsRepository.findByLeagueSeasonId(10L)).willReturn(Optional.of(standings));
+
+        service.deleteLeagueSeasonStandings(10L);
+
+        then(leagueSeasonStandingsMongoRepository).should(never()).deleteByLeagueSeasonId(any());
+        then(leagueSeasonStandingsRepository).should().delete(standings);
+    }
+
+    private LeagueSeasonStandingsCreateRequest createRequest(
+            Long leagueSeasonId,
+            LeagueSeasonStandingsType standingsType
+    ) {
+        LeagueSeasonStandingsCreateRequest request = mock(LeagueSeasonStandingsCreateRequest.class);
+        given(request.getLeagueSeasonId()).willReturn(leagueSeasonId);
+        given(request.getStandingsType()).willReturn(standingsType);
+        return request;
+    }
+
+    private LeagueSeason season(Long id, League league) {
+        LeagueSeason leagueSeason = LeagueSeason.create(
+                league.getId(),
+                "2025/26",
+                LocalDate.of(2025, 8, 1),
+                LocalDate.of(2026, 5, 31),
+                true
+        );
+        ReflectionTestUtils.setField(leagueSeason, "id", id);
+        ReflectionTestUtils.setField(leagueSeason, "league", league);
+        return leagueSeason;
+    }
+
+    private LeagueSeasonStandings standings(Long leagueSeasonId, LeagueSeasonStandingsType type) {
+        return LeagueSeasonStandings.builder()
+                .leagueSeasonId(leagueSeasonId)
+                .standingsType(type)
+                .build();
+    }
+
+    private League manualLeague(Long id) {
+        return League.builder()
+                .id(id)
+                .kName("수동 리그")
+                .dataOrigin(DataOrigin.MANUAL)
+                .build();
+    }
+
+    private League betsLeague(Long id) {
+        return League.builder()
+                .id(id)
+                .kName("외부 리그")
+                .dataOrigin(DataOrigin.BETS)
+                .build();
+    }
+}

--- a/src/test/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonStandingsServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/league/service/AdminLeagueSeasonStandingsServiceTest.java
@@ -2,6 +2,7 @@ package com.scorenow.scorenow_api.domain.league.service;
 
 import com.scorenow.scorenow_api.domain.common.enums.DataOrigin;
 import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsCreateRequest;
+import com.scorenow.scorenow_api.domain.league.dto.request.LeagueSeasonStandingsTypeUpdateRequest;
 import com.scorenow.scorenow_api.domain.league.entity.League;
 import com.scorenow.scorenow_api.domain.league.entity.LeagueExternalMapping;
 import com.scorenow.scorenow_api.domain.league.entity.LeagueSeason;
@@ -159,6 +160,102 @@ class AdminLeagueSeasonStandingsServiceTest {
     }
 
     @Test
+    void 이미지_타입을_외부_데이터_타입으로_변경한다() {
+        LeagueSeason leagueSeason = season(10L, betsLeague(1L));
+        LeagueSeasonStandings standings = standings(10L, LeagueSeasonStandingsType.IMAGE, leagueSeason);
+        standings.updateImageUrl("https://cdn.example.com/standing.png");
+
+        given(leagueSeasonStandingsRepository.findByLeagueSeasonIdWithSeasonAndLeague(10L))
+                .willReturn(Optional.of(standings));
+        given(leagueExternalMappingRepository.findByDataOriginAndInternalLeagueId(DataOrigin.BETS, 1L))
+                .willReturn(Optional.of(LeagueExternalMapping.of(DataOrigin.BETS, "94", 1L, true)));
+
+        service.updateLeagueSeasonStandingsType(
+                10L,
+                updateTypeRequest(LeagueSeasonStandingsType.EXTERNAL_DATA)
+        );
+
+        assertThat(standings.getStandingsType()).isEqualTo(LeagueSeasonStandingsType.EXTERNAL_DATA);
+        assertThat(standings.getImageUrl()).isEqualTo("https://cdn.example.com/standing.png");
+        then(leagueSeasonStandingsMongoRepository).should(never()).deleteByLeagueSeasonId(any());
+    }
+
+    @Test
+    void 외부_데이터_타입을_이미지_타입으로_변경한다() {
+        LeagueSeason leagueSeason = season(10L, betsLeague(1L));
+        LeagueSeasonStandings standings = standings(10L, LeagueSeasonStandingsType.EXTERNAL_DATA, leagueSeason);
+
+        given(leagueSeasonStandingsRepository.findByLeagueSeasonIdWithSeasonAndLeague(10L))
+                .willReturn(Optional.of(standings));
+
+        service.updateLeagueSeasonStandingsType(
+                10L,
+                updateTypeRequest(LeagueSeasonStandingsType.IMAGE)
+        );
+
+        assertThat(standings.getStandingsType()).isEqualTo(LeagueSeasonStandingsType.IMAGE);
+        then(leagueExternalMappingRepository).should(never()).findByDataOriginAndInternalLeagueId(any(), any());
+        then(leagueSeasonStandingsMongoRepository).should(never()).deleteByLeagueSeasonId(any());
+    }
+
+    @Test
+    void 동일한_타입으로_변경하면_아무것도_하지_않는다() {
+        LeagueSeasonStandings standings = standings(10L, LeagueSeasonStandingsType.IMAGE);
+        given(leagueSeasonStandingsRepository.findByLeagueSeasonIdWithSeasonAndLeague(10L))
+                .willReturn(Optional.of(standings));
+
+        service.updateLeagueSeasonStandingsType(
+                10L,
+                updateTypeRequest(LeagueSeasonStandingsType.IMAGE)
+        );
+
+        assertThat(standings.getStandingsType()).isEqualTo(LeagueSeasonStandingsType.IMAGE);
+        then(leagueExternalMappingRepository).should(never()).findByDataOriginAndInternalLeagueId(any(), any());
+        then(leagueSeasonStandingsMongoRepository).should(never()).deleteByLeagueSeasonId(any());
+    }
+
+    @Test
+    void 수동_관리_리그는_외부_데이터_타입으로_변경할_수_없다() {
+        LeagueSeason leagueSeason = season(10L, manualLeague(1L));
+        LeagueSeasonStandings standings = standings(10L, LeagueSeasonStandingsType.IMAGE, leagueSeason);
+
+        given(leagueSeasonStandingsRepository.findByLeagueSeasonIdWithSeasonAndLeague(10L))
+                .willReturn(Optional.of(standings));
+
+        assertThatThrownBy(() -> service.updateLeagueSeasonStandingsType(
+                10L,
+                updateTypeRequest(LeagueSeasonStandingsType.EXTERNAL_DATA)
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        assertThat(standings.getStandingsType()).isEqualTo(LeagueSeasonStandingsType.IMAGE);
+        then(leagueExternalMappingRepository).should(never()).findByDataOriginAndInternalLeagueId(any(), any());
+    }
+
+    @Test
+    void 외부_데이터_타입으로_변경할때_외부_매핑이_없으면_실패한다() {
+        LeagueSeason leagueSeason = season(10L, betsLeague(1L));
+        LeagueSeasonStandings standings = standings(10L, LeagueSeasonStandingsType.IMAGE, leagueSeason);
+
+        given(leagueSeasonStandingsRepository.findByLeagueSeasonIdWithSeasonAndLeague(10L))
+                .willReturn(Optional.of(standings));
+        given(leagueExternalMappingRepository.findByDataOriginAndInternalLeagueId(DataOrigin.BETS, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateLeagueSeasonStandingsType(
+                10L,
+                updateTypeRequest(LeagueSeasonStandingsType.EXTERNAL_DATA)
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        assertThat(standings.getStandingsType()).isEqualTo(LeagueSeasonStandingsType.IMAGE);
+    }
+
+    @Test
     void 외부_데이터_타입이면_수동_동기화를_호출한다() {
         given(leagueSeasonStandingsRepository.findByLeagueSeasonId(10L))
                 .willReturn(Optional.of(standings(10L, LeagueSeasonStandingsType.EXTERNAL_DATA)));
@@ -193,13 +290,13 @@ class AdminLeagueSeasonStandingsServiceTest {
     }
 
     @Test
-    void 이미지_타입_순위_관리를_삭제하면_Mongo_문서는_삭제하지_않는다() {
+    void 이미지_타입_순위_관리를_삭제해도_Mongo_문서를_삭제한다() {
         LeagueSeasonStandings standings = standings(10L, LeagueSeasonStandingsType.IMAGE);
         given(leagueSeasonStandingsRepository.findByLeagueSeasonId(10L)).willReturn(Optional.of(standings));
 
         service.deleteLeagueSeasonStandings(10L);
 
-        then(leagueSeasonStandingsMongoRepository).should(never()).deleteByLeagueSeasonId(any());
+        then(leagueSeasonStandingsMongoRepository).should().deleteByLeagueSeasonId(10L);
         then(leagueSeasonStandingsRepository).should().delete(standings);
     }
 
@@ -211,6 +308,12 @@ class AdminLeagueSeasonStandingsServiceTest {
         given(request.getLeagueSeasonId()).willReturn(leagueSeasonId);
         given(request.getStandingsType()).willReturn(standingsType);
         return request;
+    }
+
+    private LeagueSeasonStandingsTypeUpdateRequest updateTypeRequest(LeagueSeasonStandingsType standingsType) {
+        return LeagueSeasonStandingsTypeUpdateRequest.builder()
+                .standingsType(standingsType)
+                .build();
     }
 
     private LeagueSeason season(Long id, League league) {
@@ -230,6 +333,18 @@ class AdminLeagueSeasonStandingsServiceTest {
         return LeagueSeasonStandings.builder()
                 .leagueSeasonId(leagueSeasonId)
                 .standingsType(type)
+                .build();
+    }
+
+    private LeagueSeasonStandings standings(
+            Long leagueSeasonId,
+            LeagueSeasonStandingsType type,
+            LeagueSeason leagueSeason
+    ) {
+        return LeagueSeasonStandings.builder()
+                .leagueSeasonId(leagueSeasonId)
+                .standingsType(type)
+                .leagueSeason(leagueSeason)
                 .build();
     }
 

--- a/src/test/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncServiceTest.java
@@ -19,6 +19,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,6 +91,45 @@ class LeagueSeasonStandingsSyncServiceTest {
 
         then(mapper).should(never()).toDocument(any(), any());
         then(mongoTemplate).should(never()).upsert(any(Query.class), any(Update.class), eq(LeagueSeasonStandingsDataDocument.class));
+    }
+
+    @Test
+    void 결과가_null_요소만_있으면_동기화에_실패한다() {
+        LeagueSeasonStandingsSyncTarget target = syncTarget();
+        BetsStandingsResponse response = response(1, Collections.singletonList(null));
+        given(syncTargetReader.read(10L)).willReturn(target);
+        given(betsApiClient.getStandings("94")).willReturn(response);
+
+        assertThatThrownBy(() -> syncService.sync(10L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        then(mapper).should(never()).toDocument(any(), any());
+        then(mongoTemplate).should(never()).upsert(any(Query.class), any(Update.class), eq(LeagueSeasonStandingsDataDocument.class));
+    }
+
+    @Test
+    void 첫번째_결과가_null이면_다음_유효한_결과로_동기화한다() {
+        LeagueSeasonStandingsSyncTarget target = syncTarget();
+        BetsStandingsResponse.Result result = new BetsStandingsResponse.Result();
+        BetsStandingsResponse response = response(1, Arrays.asList(null, result));
+        LeagueSeasonStandingsDataDocument document = LeagueSeasonStandingsDataDocument.builder()
+                .leagueId(1L)
+                .apiLeagueId("94")
+                .dataOrigin(DataOrigin.BETS)
+                .leagueSeasonId(10L)
+                .externalSeasonName("2025/26")
+                .build();
+
+        given(syncTargetReader.read(10L)).willReturn(target);
+        given(betsApiClient.getStandings("94")).willReturn(response);
+        given(mapper.toDocument(result, target)).willReturn(document);
+
+        syncService.sync(10L);
+
+        then(mapper).should().toDocument(result, target);
+        then(mongoTemplate).should().upsert(any(Query.class), any(Update.class), eq(LeagueSeasonStandingsDataDocument.class));
     }
 
     @Test

--- a/src/test/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncServiceTest.java
+++ b/src/test/java/com/scorenow/scorenow_api/domain/league/service/LeagueSeasonStandingsSyncServiceTest.java
@@ -1,0 +1,155 @@
+package com.scorenow.scorenow_api.domain.league.service;
+
+import com.scorenow.scorenow_api.domain.common.enums.DataOrigin;
+import com.scorenow.scorenow_api.domain.league.document.LeagueSeasonStandingsDataDocument;
+import com.scorenow.scorenow_api.domain.league.dto.LeagueSeasonStandingsSyncTarget;
+import com.scorenow.scorenow_api.domain.league.mapper.LeagueSeasonStandingsMapper;
+import com.scorenow.scorenow_api.external.betsapi.BetsApiClient;
+import com.scorenow.scorenow_api.external.betsapi.dto.BetsStandingsResponse;
+import com.scorenow.scorenow_api.global.exception.BusinessException;
+import com.scorenow.scorenow_api.global.exception.ErrorCode;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class LeagueSeasonStandingsSyncServiceTest {
+
+    @Mock
+    private LeagueSeasonStandingsSyncTargetReader syncTargetReader;
+
+    @Mock
+    private BetsApiClient betsApiClient;
+
+    @Mock
+    private MongoTemplate mongoTemplate;
+
+    @Mock
+    private LeagueSeasonStandingsMapper mapper;
+
+    @InjectMocks
+    private LeagueSeasonStandingsSyncService syncService;
+
+    @Test
+    void 응답이_null이면_동기화에_실패한다() {
+        LeagueSeasonStandingsSyncTarget target = syncTarget();
+        given(syncTargetReader.read(10L)).willReturn(target);
+        given(betsApiClient.getStandings("94")).willReturn(null);
+
+        assertThatThrownBy(() -> syncService.sync(10L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        then(mapper).should(never()).toDocument(any(), any());
+        then(mongoTemplate).should(never()).upsert(any(Query.class), any(Update.class), eq(LeagueSeasonStandingsDataDocument.class));
+    }
+
+    @Test
+    void success가_1이_아니면_동기화에_실패한다() {
+        LeagueSeasonStandingsSyncTarget target = syncTarget();
+        BetsStandingsResponse response = response(0, List.of(new BetsStandingsResponse.Result()));
+        given(syncTargetReader.read(10L)).willReturn(target);
+        given(betsApiClient.getStandings("94")).willReturn(response);
+
+        assertThatThrownBy(() -> syncService.sync(10L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_PARAMETER);
+
+        then(mapper).should(never()).toDocument(any(), any());
+        then(mongoTemplate).should(never()).upsert(any(Query.class), any(Update.class), eq(LeagueSeasonStandingsDataDocument.class));
+    }
+
+    @Test
+    void 결과가_없으면_Mongo에_저장하지_않는다() {
+        LeagueSeasonStandingsSyncTarget target = syncTarget();
+        BetsStandingsResponse response = response(1, List.of());
+        given(syncTargetReader.read(10L)).willReturn(target);
+        given(betsApiClient.getStandings("94")).willReturn(response);
+
+        syncService.sync(10L);
+
+        then(mapper).should(never()).toDocument(any(), any());
+        then(mongoTemplate).should(never()).upsert(any(Query.class), any(Update.class), eq(LeagueSeasonStandingsDataDocument.class));
+    }
+
+    @Test
+    void 정상_응답이면_문서로_변환하고_Mongo에_upsert한다() {
+        LeagueSeasonStandingsSyncTarget target = syncTarget();
+        BetsStandingsResponse.Result result = new BetsStandingsResponse.Result();
+        BetsStandingsResponse response = response(1, List.of(result));
+        LeagueSeasonStandingsDataDocument document = LeagueSeasonStandingsDataDocument.builder()
+                .leagueId(1L)
+                .apiLeagueId("94")
+                .dataOrigin(DataOrigin.BETS)
+                .leagueSeasonId(10L)
+                .externalSeasonName("2025/26")
+                .build();
+
+        given(syncTargetReader.read(10L)).willReturn(target);
+        given(betsApiClient.getStandings("94")).willReturn(response);
+        given(mapper.toDocument(result, target)).willReturn(document);
+
+        syncService.sync(10L);
+
+        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+        ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+        then(mongoTemplate).should().upsert(
+                queryCaptor.capture(),
+                updateCaptor.capture(),
+                eq(LeagueSeasonStandingsDataDocument.class)
+        );
+
+        Document query = queryCaptor.getValue().getQueryObject();
+        Document setValues = updateCaptor.getValue().getUpdateObject().get("$set", Document.class);
+
+        assertThat(query.get("leagueSeasonId")).isEqualTo(10L);
+        assertThat(setValues).containsKeys(
+                "leagueId",
+                "apiLeagueId",
+                "dataOrigin",
+                "leagueSeasonId",
+                "externalSeasonName",
+                "externalSeasonStartAt",
+                "externalSeasonEndAt",
+                "standingsTable"
+        );
+        assertThat(setValues.get("leagueSeasonId")).isEqualTo(10L);
+        assertThat(setValues.get("externalSeasonName")).isEqualTo("2025/26");
+    }
+
+    private LeagueSeasonStandingsSyncTarget syncTarget() {
+        return LeagueSeasonStandingsSyncTarget.builder()
+                .leagueSeasonStandingsId(100L)
+                .leagueSeasonId(10L)
+                .leagueId(1L)
+                .dataOrigin(DataOrigin.BETS)
+                .apiLeagueId("94")
+                .build();
+    }
+
+    private BetsStandingsResponse response(Integer success, List<BetsStandingsResponse.Result> results) {
+        BetsStandingsResponse response = new BetsStandingsResponse();
+        response.setSuccess(success);
+        response.setResults(results);
+        return response;
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number
- #110 

## 📝 요약(Summary)
- 리그 시즌 관리 기능 추가 `LeagueSeason`
  - 리그별 시즌 생성/검색/수정/삭제
  - 현재 시즌 설정 시 기존 현재 시즌 해제
  - 시즌명 중복, 시즌 기간 겹침, 기간 유효성 검증
  - 시즌 삭제는 soft delete 처리

- 리그 시즌 순위 관리 기능 추가 `LeagueSeasonStandings`
  - 시즌 기준 순위 관리 타입 등록
  - `IMAGE` / `EXTERNAL_DATA` 관리 타입 지원
  - 순위 관리 타입 수정 기능 추가
    - `IMAGE -> EXTERNAL_DATA`
    - `EXTERNAL_DATA -> IMAGE`
    - 타입 변경 시 기존 `imageUrl`과 MongoDB 외부 순위 문서는 삭제하지 않음
    - `EXTERNAL_DATA` 변경 시 외부 리그 매핑 존재 여부 검증
  - 이미지 타입 순위 이미지 업로드
  - 외부 데이터 타입 수동 동기화
  - 순위 관리 삭제 시 타입과 무관하게 연결된 MongoDB 외부 순위 문서 삭제

- 외부 순위 데이터 저장 구조 추가 `LeagueSeasonStandingsDataDocument`
  - MySQL에는 내부 기준 데이터와 관리 설정 저장
  - MongoDB에는 외부 API 순위 응답 document 저장
  - `leagueSeasonId` 기준 unique index 및 upsert 처리

- 외부 순위 동기화 구조 추가
  - 동기화 대상 reader 분리
  - 외부 API 응답 DTO와 MongoDB document 변환 mapper 추가
  - 매일 08:30 / 20:30 KST 스케줄러 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 내부 시즌 정보는 외부 API 응답이 아니라 `LeagueSeason`을 기준으로 합니다.
  - 외부 API의 시즌명/시즌 기간은 MongoDB에 provider 메타데이터로만 저장합니다.
- 이미지 URL은 관리자 목록에서 등록 여부를 바로 판단하기 위해 MySQL `league_season_standings.image_url`에 저장합니다.
- 순위 관리 타입 변경은 콘텐츠를 삭제하지 않는 정책입니다.
  - `IMAGE -> EXTERNAL_DATA`: 기존 `imageUrl` 유지
  - `EXTERNAL_DATA -> IMAGE`: 기존 MongoDB 순위 문서 유지
- 순위 관리 설정 삭제는 타입 변경과 다르게 연결된 MongoDB 순위 문서까지 삭제합니다.
- 스케줄러는 현재 시즌이면서 + `isActive=true` + `EXTERNAL_DATA` 타입만 동기화합니다.


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
