### PR TITLE
fix : 개발 서버 옵션 변경

### DIFF
--- a/src/main/java/com/scorenow/scorenow_api/domain/match/batch/MatchSyncJobConfig.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/match/batch/MatchSyncJobConfig.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MatchSyncJobConfig {
 
-	private static final int UPCOMING_DAYS = 31;
+	private static final int UPCOMING_DAYS = 2;
 	private final JobRepository jobRepository;
 	private final PlatformTransactionManager transactionManager;
 	private final MatchSyncService matchSyncService;

--- a/src/main/java/com/scorenow/scorenow_api/domain/player/scheduler/PlayerSyncScheduler.java
+++ b/src/main/java/com/scorenow/scorenow_api/domain/player/scheduler/PlayerSyncScheduler.java
@@ -17,7 +17,7 @@ public class PlayerSyncScheduler {
 	private final JobLauncher jobLauncher;
 	private final Job playerSyncJob;
 
-	@Scheduled(initialDelay = 10000, fixedRate = 1000000)
+	@Scheduled(cron = "0 0 16 * * *", zone = "Asia/Seoul")
 	public void runPlayerSyncJob() throws Exception {
 		JobParameters jobParameters = new JobParametersBuilder()
 			.addString("runType", "SCHEDULED")

--- a/src/main/java/com/scorenow/scorenow_api/global/config/SchedulerConfig.java
+++ b/src/main/java/com/scorenow/scorenow_api/global/config/SchedulerConfig.java
@@ -1,0 +1,29 @@
+package com.scorenow.scorenow_api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class SchedulerConfig implements SchedulingConfigurer {
+
+    private static final int SCHEDULER_POOL_SIZE = 4;
+
+    @Bean(name = "taskScheduler")
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(SCHEDULER_POOL_SIZE);
+        scheduler.setThreadNamePrefix("sn-scheduler-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);    // 종료 시 작업을 바로 끊지 않고 기다림
+        scheduler.setAwaitTerminationSeconds(30);               // 최대 30초 까지
+        scheduler.initialize();
+        return scheduler;
+    }
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        taskRegistrar.setTaskScheduler(taskScheduler());
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -47,7 +47,7 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: DEBUG
+    org.hibernate.SQL: OFF
 
 betsapi:
   base-url: https://api.b365api.com


### PR DESCRIPTION
## 📝 요약(Summary)
- 기존 클라우드 런 콘솔에서 SQL 관련 로그가 많이 찍혀있어 로그 확인 시 불편함이 존재 
   → SQL 관련 로그는 찍히지 않게끔 변경

- 예정 경기 (Upcoming) 동기화 배치 범위 변경
   - 기존에는 31일치를 매일 4, 16시에 동기화
   - 변경후에는 2일치를 매일 4, 16시에 동기화
   - 한달치 동기화도 물론 필요하기 때문에 (클라이언트 대상으로 더 넓은 범위의 예정 경기를 보여줘야 하기 때문),
       해당 기능은 별도의 관리자 페이지에서 수동 동기화 버튼을 통해 해결하는 방향으로 진행해야 할 듯.

- 스케줄러 전용 스레드풀 설정
   - Websocket 에서 사용하는 스레드풀을 스케줄링 처리할 때 공유하고 있음.
   - 별도의 스케줄링 전용 스레드풀을 설정
   
- 선수 동기화 스케줄러 `PlayerSyncScheduler` 작업 주기 변경 @hailyn-k 
   - 기존에는  `@Scheduled(initialDelay = 10000, fixedRate = 1000000)`  => 약 16분 40초 마다 돔
   - 해당 작업이 너무 무겁다고 판단되어, 일단 클라우드 런이 깨어나는 시간인 16시에 해당 스케줄링이 1일 1회 돌 수 있게끔 변경
     `@Scheduled(cron = "0 0 16 * * *", zone = "Asia/Seoul")`